### PR TITLE
Offers links hope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1757,7 +1757,11 @@ However, this section covers some basics of what to expect with offers, and tips
 
 ### Offers
 
-🔹 Companies can and should work hard to ensure that all candidates are [given equal treatment](https://rework.withgoogle.com/guides/pay-equity/steps/introduction/) in the hiring process. But candidates should also know their worth and understand that they can negotiate to get better offers.
+🔹 Companies can and should work hard to ensure that all candidates are
+[given equal treatment](https://rework.withgoogle.com/guides/pay-equity/steps/introduction/)
+in the hiring process.
+But candidates should also know their worth and understand that they can negotiate to get
+better offers.
 
 - 🚧 Not sure what “roughly equal treatment” is meant to evoke.
   These would be the sections of this Guide to speak to the varied experiences of people who
@@ -1770,7 +1774,8 @@ However, this section covers some basics of what to expect with offers, and tips
 
 - Many companies will give some flexibility during negotiations, letting you indicate
   whether you prefer
-  [higher salary](https://hired.com/blog/candidates/salary-vs-equity-how-decide-whats-right/) or [higher equity](https://www.investopedia.com/articles/personal-finance/041515/equity-vs-salary-what-you-need-know.asp).
+  [higher salary](https://hired.com/blog/candidates/salary-vs-equity-how-decide-whats-right/) or
+  [higher equity](https://www.investopedia.com/articles/personal-finance/041515/equity-vs-salary-what-you-need-know.asp).
 - Candidates with
   [competing offers](https://www.shrm.org/resourcesandtools/hr-topics/employee-relations/pages/using-a-job-offer-as-leverage-is-no-longer-a-big-no-no.aspx)
   almost always have more leverage and get better offers.
@@ -1802,8 +1807,8 @@ manager, your future manager, or a recruiter, or some combination) multiple time
 signing. This helps you negotiate details and offers you a chance to get to know the
 people, the company, and the role, so that you can make the best decision for you.
 
-Things to look for in [the offer letter](https://www.glassdoor.com/blog/how-to-read-offer-letter/)
-include:
+Things to look for in
+[the offer letter](https://www.glassdoor.com/blog/how-to-read-offer-letter/) include:
 
 - Title and level:
   What your role is officially called, who you report to, and what level of seniority your
@@ -1847,24 +1852,27 @@ Which come from Cordova?
 Because startups are so much smaller than many established companies, and because they may
 grow quickly, a few other things are worth remembering when negotiating with startups:
 
-- **Cash versus equity**: If your [risk tolerance](https://www.investopedia.com/terms/r/risktolerance.asp) is reasonably high, it’s reasonable to ask for
-  an offer with more equity and less cash.
+- **Cash versus equity**: If your
+  [risk tolerance](https://www.investopedia.com/terms/r/risktolerance.asp) is reasonably high,
+  it’s reasonable to ask for an offer with more equity and less cash.
 
   - 🚧 More discussion (perhaps in the intro to the Guide) about risk.
     What is risk? What is risk tolerance and how do I know if I have it?
     Should I be risk tolerant?
     What can I look for in the company to determine whether it’s worth a “risk”?
 
-  If a company begins to do well, it’ll likely [“level up”](https://bothsidesofthetable.com/this-is-how-startups-level-up-after-raising-money-328d17076515) lower salaries (bringing them
-  closer to market average) even if you got more equity up front.
-  On the other hand, if you ask for more cash and less equity, it’s unlikely you’ll be able
-  to negotiate to get more equity later on, since equity is increasingly scarce over time
-  (at least in a successful company!).
+  If a company begins to do well, it’ll likely
+  [“level up”](https://bothsidesofthetable.com/this-is-how-startups-level-up-after-raising-money-328d17076515)
+  lower salaries (bringing them closer to market average) even if you got more equity up
+  front. On the other hand, if you ask for more cash and less equity, it’s unlikely you’ll
+  be able to negotiate to get more equity later on, since equity is increasingly scarce over
+  time (at least in a successful company!).
 
 - Negotiating title and exact details of your role early on may not matter as much in a
   small and growing company, because your role and the role of others may change a lot
   quickly. It’s more important that you respect the founders and leaders of the company.
-  It’s more important that you feel [you are respected](https://blog.shrm.org/blog/respect-and-trust-top-the-list-of-most-important-employee-job-satisfaction).
+  It’s more important that you feel
+  [you are respected](https://blog.shrm.org/blog/respect-and-trust-top-the-list-of-most-important-employee-job-satisfaction).
 
 ### Typical employee equity levels
 
@@ -1924,13 +1932,15 @@ going to exceed it, at least not by much.
 
 Some points on negotiating compensation:
 
-- [Some argue](http://www.businessinsider.com/how-to-negotiate-make-first-offer-2014-5) that a good tactic in negotiating is to start higher than you will be willing
-  to accept, so that the other party can “win” by negotiating you down a little bit.
+- [Some argue](http://www.businessinsider.com/how-to-negotiate-make-first-offer-2014-5) that a
+  good tactic in negotiating is to start higher than you will be willing to accept, so that
+  the other party can “win” by negotiating you down a little bit.
   Keep in mind, this is just a suggested tactic, and not a hard and fast rule.
 - If you are inexperienced and are unsure what a fair offer should look like, avoid saying
   exactly what you want for compensation very early in discussions.
   It’s common for hiring managers or recruiters to ask this early in the process, just to
-  take advantage of candidates who don’t have a good sense of [their own worth](https://nuleadership.com/2018/01/08/know-your-worth-compensation-negotiation/).
+  take advantage of candidates who don’t have a good sense of
+  [their own worth](https://nuleadership.com/2018/01/08/know-your-worth-compensation-negotiation/).
   Tell them you want to focus on the opportunity as a whole and your ability to contribute
   before discussing numbers.
   Ask them to give you a fair offer once they understand your worth to the company.
@@ -1943,11 +1953,14 @@ Some points on negotiating compensation:
   agree what those could look like *if* you demonstrate outstanding performance and the
   company has money.
 - If you’re moving from an established company to a startup, you may be asked to take a
-  [salary cut](http://fortune.com/2016/06/13/new-job-pay-cut-leadership/). This is reasonable, but it’s wise to discuss explicitly how much the cut is,
-  and when your salary will be renegotiated.
-  For example, you might take 25% below your previous salary, but there can be an agreement
-  that this will be corrected if your performance is strong and the company gets funding.
-- 🔹 Always negotiate [non-compensation aspects](http://time.com/money/4391908/job-offer-negotiations/) before agreeing to an offer.
+  [salary cut](http://fortune.com/2016/06/13/new-job-pay-cut-leadership/). This is reasonable,
+  but it’s wise to discuss explicitly how much the cut is, and when your salary will be
+  renegotiated. For example, you might take 25% below your previous salary, but there can be
+  an agreement that this will be corrected if your performance is strong and the company
+  gets funding.
+- 🔹 Always negotiate
+  [non-compensation aspects](http://time.com/money/4391908/job-offer-negotiations/) before
+  agreeing to an offer.
   If you want a specific role, title, opportunity, visa sponsorship, parental leave, special
   treatment (like working from home), or have timing constraints about when you can join,
   negotiate these early, not late in the process.
@@ -1974,10 +1987,13 @@ Some notes on the negotiation process itself:
   [make no sense at all](https://erikbern.com/2016/03/16/exploding-offers-are-bullshit.html). If
   you are likely the best candidate for the position, or the role is a specialized and
   well-paid one where there are usually not enough good candidates to meet the demand,
-  you’ll likely have plenty of leverage to [ask for more time](http://www.businessinsider.com/how-to-politely-postpone-accepting-a-job-offer-2015-6#dont-be-afraid-to-negotiate-4), such as to complete the
-  interview process with other companies.
+  you’ll likely have plenty of leverage to
+  [ask for more time](http://www.businessinsider.com/how-to-politely-postpone-accepting-a-job-offer-2015-6#dont-be-afraid-to-negotiate-4),
+  such as to complete the interview process with other companies.
   For example, software engineering roles in tech companies are like this currently.
-- Getting [multiple offers](https://www.themuse.com/advice/a-guide-to-juggling-multiple-job-offers-and-coming-out-on-top) is always in your interest.
+- Getting
+  [multiple offers](https://www.themuse.com/advice/a-guide-to-juggling-multiple-job-offers-and-coming-out-on-top)
+  is always in your interest.
   If you have competing offers, sharing the competing offers with the company you want to
   work for can be helpful, granted your offers are competitive.
   - However, dragging out negotiations excessively so you can “shop around” an offer to other
@@ -1986,7 +2002,8 @@ Some notes on the negotiation process itself:
 - ❗ Get all agreements in writing, if they are not in your offer letter.
 - **Reneging on offers**: Do not accept an offer verbally or in writing unless you’re ready to
   stand by your word.
-  In practice, people do occasionally accept an offer and then go back on it, or [renege](https://purduecco.wordpress.com/2016/03/28/the-risks-of-reneging-on-a-job-offer/).
+  In practice, people do occasionally accept an offer and then go back on it, or
+  [renege](https://purduecco.wordpress.com/2016/03/28/the-risks-of-reneging-on-a-job-offer/).
   This can put the company in a difficult position (they may have declined another key
   candidate based on your acceptance), and may hurt your reputation in unexpected ways
   later.
@@ -2047,22 +2064,28 @@ It’s not exhaustive, as titles and details vary.
 
 - When you are considering your offer from the company, make sure you have all of the
   documents you need:
-  - Your offer letter, which will detail salary, benefits, and equity compensation.
-  - An Employee Innovations Agreement, Proprietary Information and Inventions Assignment
-    Agreement, or similar, concerning intellectual property.
+  - 📥 Your [offer letter](https://www.upcounsel.com/employee-offer-letter), which will detail
+    salary, benefits, and equity compensation.
+  - 📥 An
+    [Employee Innovations Agreement](https://recruit.smashfly.com/SmashFlyMedia/Docs/12250/12250_168_United%20States%20-%20EIPIA%20English%20%28Rev%2014%20FEBRUARY%202017%29%202%20pages.pdf),
+    Proprietary Information and Inventions Assignment Agreement, or similar, concerning
+    intellectual property.
 - If you have equity compensation, at some point—possibly weeks or months after you’ve
   joined—you should get a Summary of Stock Grant, Notice of Stock Option Grant, or similar
   document, detailing your grant of stock or options, along with all details such as number
   of shares, type of options, grant date, vesting commencement date, and vesting schedule.
   It will come with several other documents, which may be exhibits to that agreement:
-  - Stock Option Agreement
-  - Stock Plan (sometimes called a Stock Option Plan, or Stock Award Plan, or Equity Incentive
-    Plan)
-  - Code Section 409A Waiver and Release (sometimes part of the Stock Option Agreement)
+  - 📥 [Stock Option Agreement](https://www.upcounsel.com/stock-option-agreement)
+  - 📥 [Stock Plan](https://www.upcounsel.com/equity-incentive-plan) (sometimes called a Stock
+    Option Plan, or Stock Award Plan, or Equity Incentive Plan)
+  - 📥
+    [Code Section 409A Waiver and Release](https://www.lawinsider.com/clause/code-section-409a-waiver-and-release)
+    (sometimes part of the Stock Option Agreement)
 - If you are exercising your options, you should also see paperwork to assist with that
   purchase:
-  - Exercise Agreement
-  - Instructions and template for early exercise and 83(b) election, if applicable
+  - 📥 [Exercise Agreement](https://www.upcounsel.com/option-exercise-agreement)
+  - 📥 Instructions and template for early exercise and
+    [83(b) election](https://www.irs.gov/pub/irs-drop/rp-12-29.pdf), if applicable
 - End of year tax documents
   - 📥 You should receive a form
     [3921 or 3922](https://www.irs.gov/uac/form-3921-exercise-of-an-incentive-stock-option-under-section-422-b)

--- a/README.md
+++ b/README.md
@@ -1938,8 +1938,10 @@ Some points on negotiating compensation:
   Keep in mind, this is just a suggested tactic, and not a hard and fast rule.
 - If you are inexperienced and are unsure what a fair offer should look like, avoid saying
   exactly what you want for compensation very early in discussions.
-  It’s common for hiring managers or recruiters to ask this early in the process, just to
-  take advantage of candidates who don’t have a good sense of
+  Though many hiring managers and recruiters ask about
+  [salary expectations](http://fistfuloftalent.com/2018/01/ask-salary-without-asking-salary-expectations.html)
+  early in the process to avoid risk at the offer stage, some ask to take advantage of
+  candidates who don’t have a good sense of
   [their own worth](https://nuleadership.com/2018/01/08/know-your-worth-compensation-negotiation/).
   Tell them you want to focus on the opportunity as a whole and your ability to contribute
   before discussing numbers.

--- a/README.md
+++ b/README.md
@@ -2056,12 +2056,18 @@ However, this section covers some basics of what to expect with offers, and tips
 🔹 Companies can and should work hard to ensure that all candidates are
 [given equal treatment](https://rework.withgoogle.com/guides/pay-equity/steps/introduction/)
 in the hiring process but
-[inequalities persist](https://iwpr.org/publications/gender-wage-gap-2017-race-ethnicity/). [Workplace disparities](https://digitalcommons.ilr.cornell.edu/cgi/viewcontent.cgi?article=2208&context=articles) in pay and opportunity span race and gender, with research focusing on the [US market](http://www.pewresearch.org/fact-tank/2016/07/01/racial-gender-wage-gaps-persist-in-u-s-despite-some-progress/) as a whole,  [executive leadership](https://digitalcommons.ilr.cornell.edu/cgi/viewcontent.cgi?article=2208&context=articles) and its well documented [lack of diversity](http://fortune.com/2017/06/09/white-men-senior-executives-fortune-500-companies-diversity-data/), and the [technology industry](https://www.eeoc.gov/eeoc/statistics/reports/hightech/).
-More effort is needed to close the gap but candidates should know their worth and understand that they can negotiate to get better
-offers.
-
-Candidates should know their worth and understand that they can negotiate to get better
-offers.
+[inequalities persist](https://iwpr.org/publications/gender-wage-gap-2017-race-ethnicity/).
+[Workplace disparities](https://digitalcommons.ilr.cornell.edu/cgi/viewcontent.cgi?article=2208&context=articles)
+in pay and opportunity span race and gender, with research focusing on
+[inequality in the U.S. workplace](http://www.pewresearch.org/fact-tank/2016/07/01/racial-gender-wage-gaps-persist-in-u-s-despite-some-progress/),
+[executive leadership](https://digitalcommons.ilr.cornell.edu/cgi/viewcontent.cgi?article=2208&context=articles)
+and its well documented
+[lack of diversity](http://fortune.com/2017/06/09/white-men-senior-executives-fortune-500-companies-diversity-data/),
+and the [technology industry](https://www.eeoc.gov/eeoc/statistics/reports/hightech/).
+[Gender bias](https://www.newyorker.com/science/maria-konnikova/lean-out-the-dangers-for-women-who-negotiate)
+in negotiation is also an issue, making many women feel uncomfortable negotiating.
+More effort is needed to end biases and close the wage gap but candidates should know
+their worth and understand that they can negotiate to get better offers.
 
 - 🚧 Not sure what “roughly equal treatment” is meant to evoke.
   These would be the sections of this Guide to speak to the varied experiences of people who
@@ -2161,12 +2167,14 @@ grow quickly, a few other things are worth remembering when negotiating with sta
     Should I be risk tolerant?
     What can I look for in the company to determine whether it’s worth a “risk”?
 
-  If a company begins to do well, it’ll likely
-  [“level up”](https://bothsidesofthetable.com/this-is-how-startups-level-up-after-raising-money-328d17076515)
-  lower salaries (bringing them closer to market average) even if you got more equity up
-  front. On the other hand, if you ask for more cash and less equity, it’s unlikely you’ll
-  be able to negotiate to get more equity later on, since equity is increasingly scarce over
-  time (at least in a successful company!).
+     If a company begins to do well, it’ll likely “level up" lower salaries (bringing them
+    closer to market average) even if you got more equity up front.
+    On the other hand, if you ask for more cash and less equity, it’s unlikely you’ll be able
+    to negotiate to get more equity later on, since equity is increasingly scarce over time
+    (at least in a successful company!). [Mark Suster](https://en.wikipedia.org/wiki/Mark_Suster),
+    entrepreneur and VC, stresses the need to
+    [level up](https://bothsidesofthetable.com/this-is-how-startups-level-up-after-raising-money-328d17076515)
+    by scaling pay, spending and focus appropriately at each funding stage.
 
 - Negotiating title and exact details of your role early on may not matter as much in a
   small and growing company, because your role and the role of others may change a lot
@@ -2230,6 +2238,15 @@ Companies will always ask you what you want for compensation, and you should alw
 If you name the lowest number you’ll accept, you can be pretty sure the company’s not
 going to exceed it, at least not by much.
 
+🔸 Asking about salary expectations is a normal part of the hiring process at most
+companies, but asking about **salary history** has been banned in a growing number of
+[states, cities and counties](https://www.hrdive.com/news/salary-history-ban-states-list/516662/).
+These laws attempt to
+[combat pay disparity](https://www.nytimes.com/2018/02/16/business/economy/salary-history-laws.html)
+among women and minorities by making it illegal for companies to ask about or consider
+candidates’ current or past compensation when making them offers.
+Make sure you understand the laws relevant to your situation.
+
 Some points on negotiating compensation:
 
 - [Some argue](http://www.businessinsider.com/how-to-negotiate-make-first-offer-2014-5) that a
@@ -2255,17 +2272,18 @@ Some points on negotiating compensation:
   agree what those could look like *if* you demonstrate outstanding performance and the
   company has money.
 - If you’re moving from an established company to a startup, you may be asked to take a
-  [salary cut](http://fortune.com/2016/06/13/new-job-pay-cut-leadership/). This is reasonable,
-  but it’s wise to discuss explicitly how much the cut is, and when your salary will be
-  renegotiated. For example, you might take 25% below your previous salary, but there can be
-  an agreement that this will be corrected if your performance is strong and the company
-  gets funding.
+  [salary cut](https://www.quora.com/Should-you-take-a-salary-cut-if-you-join-a-startup). This
+  is reasonable, but it’s wise to discuss explicitly how much the cut is, and when your
+  salary will be renegotiated.
+  For example, you might take 25% below your previous salary, but there can be an agreement
+  that this will be corrected if your performance is strong and the company gets funding.
 - 🔹 Always negotiate
-  [non-compensation aspects](http://time.com/money/4391908/job-offer-negotiations/) before
-  agreeing to an offer.
+  [non-compensation aspects](http://www.kennedyexecutive.com/blog/salary-negotiation-33-things-negotiate-money/)
+  before agreeing to an offer.
   If you want a specific role, title, opportunity, visa sponsorship, parental leave, special
   treatment (like working from home), or have timing constraints about when you can join,
-  negotiate these early, not late in the process.
+  [negotiate these early](https://www.nerdwallet.com/blog/loans/student-loans/negotiate-nonsalary-benefits-job-perks/),
+  not late in the process.
 - 🔹 If you’re going to be a very early employee, consider asking for a restricted stock
   grant instead of stock options, and a cash bonus equal to the tax on those options.
   The company will have some extra paperwork (and legal costs), but it means you won’t have

--- a/README.md
+++ b/README.md
@@ -1757,7 +1757,10 @@ However, this section covers some basics of what to expect with offers, and tips
 🔹 Companies can and should work hard to ensure that all candidates are
 [given equal treatment](https://rework.withgoogle.com/guides/pay-equity/steps/introduction/)
 in the hiring process but
-[inequalities persist](https://iwpr.org/publications/gender-wage-gap-2017-race-ethnicity/).
+[inequalities persist](https://iwpr.org/publications/gender-wage-gap-2017-race-ethnicity/). [Workplace disparities](https://digitalcommons.ilr.cornell.edu/cgi/viewcontent.cgi?article=2208&context=articles) in pay and opportunity span race and gender, with research focusing on the [US market](http://www.pewresearch.org/fact-tank/2016/07/01/racial-gender-wage-gaps-persist-in-u-s-despite-some-progress/) as a whole,  [executive leadership](https://digitalcommons.ilr.cornell.edu/cgi/viewcontent.cgi?article=2208&context=articles) and its well documented [lack of diversity](http://fortune.com/2017/06/09/white-men-senior-executives-fortune-500-companies-diversity-data/), and the [technology industry](https://www.eeoc.gov/eeoc/statistics/reports/hightech/).
+More effort is needed to close the gap but candidates should know their worth and understand that they can negotiate to get better
+offers.
+
 Candidates should know their worth and understand that they can negotiate to get better
 offers.
 

--- a/README.md
+++ b/README.md
@@ -2060,7 +2060,7 @@ in the hiring process but
 [Workplace disparities](https://digitalcommons.ilr.cornell.edu/cgi/viewcontent.cgi?article=2208&context=articles)
 in pay and opportunity span race and gender, with research focusing on
 [inequality in the U.S. workplace](http://www.pewresearch.org/fact-tank/2016/07/01/racial-gender-wage-gaps-persist-in-u-s-despite-some-progress/),
-[executive leadership](https://digitalcommons.ilr.cornell.edu/cgi/viewcontent.cgi?article=2208&context=articles)
+[executive leadership](https://pr-paywatch-aflcio.pantheonsite.io/paywatch/company-pay-ratios)
 and its well documented
 [lack of diversity](http://fortune.com/2017/06/09/white-men-senior-executives-fortune-500-companies-diversity-data/),
 and the [technology industry](https://www.eeoc.gov/eeoc/statistics/reports/hightech/).
@@ -2161,20 +2161,19 @@ grow quickly, a few other things are worth remembering when negotiating with sta
 - **Cash versus equity**: If your
   [risk tolerance](https://www.investopedia.com/terms/r/risktolerance.asp) is reasonably high,
   it’s reasonable to ask for an offer with more equity and less cash.
+  If a company begins to do well, it’ll likely “level up" lower salaries (bringing them
+  closer to market average) even if you got more equity up front.
+  On the other hand, if you ask for more cash and less equity, it’s unlikely you’ll be able
+  to negotiate to get more equity later on, since equity is increasingly scarce over time
+  (at least in a successful company!). [Mark Suster](https://en.wikipedia.org/wiki/Mark_Suster),
+  entrepreneur and VC, stresses the need to
+  [level up](https://bothsidesofthetable.com/this-is-how-startups-level-up-after-raising-money-328d17076515)
+  by scaling pay, spending and focus appropriately at each funding stage.
 
-  - 🚧 More discussion (perhaps in the intro to the Guide) about risk.
-    What is risk? What is risk tolerance and how do I know if I have it?
+  - 🚧 What is risk?
+    What is risk tolerance and how do I know if I have it?
     Should I be risk tolerant?
     What can I look for in the company to determine whether it’s worth a “risk”?
-
-     If a company begins to do well, it’ll likely “level up" lower salaries (bringing them
-    closer to market average) even if you got more equity up front.
-    On the other hand, if you ask for more cash and less equity, it’s unlikely you’ll be able
-    to negotiate to get more equity later on, since equity is increasingly scarce over time
-    (at least in a successful company!). [Mark Suster](https://en.wikipedia.org/wiki/Mark_Suster),
-    entrepreneur and VC, stresses the need to
-    [level up](https://bothsidesofthetable.com/this-is-how-startups-level-up-after-raising-money-328d17076515)
-    by scaling pay, spending and focus appropriately at each funding stage.
 
 - Negotiating title and exact details of your role early on may not matter as much in a
   small and growing company, because your role and the role of others may change a lot

--- a/README.md
+++ b/README.md
@@ -1847,7 +1847,7 @@ Which come from Cordova?
 Because startups are so much smaller than many established companies, and because they may
 grow quickly, a few other things are worth remembering when negotiating with startups:
 
-- **Cash versus equity**: If your risk tolerance is reasonably high, it’s reasonable to ask for
+- **Cash versus equity**: If your [risk tolerance](https://www.investopedia.com/terms/r/risktolerance.asp) is reasonably high, it’s reasonable to ask for
   an offer with more equity and less cash.
 
   - 🚧 More discussion (perhaps in the intro to the Guide) about risk.
@@ -1855,7 +1855,7 @@ grow quickly, a few other things are worth remembering when negotiating with sta
     Should I be risk tolerant?
     What can I look for in the company to determine whether it’s worth a “risk”?
 
-  If a company begins to do well, it’ll likely “level up” lower salaries (bringing them
+  If a company begins to do well, it’ll likely [“level up”](https://bothsidesofthetable.com/this-is-how-startups-level-up-after-raising-money-328d17076515) lower salaries (bringing them
   closer to market average) even if you got more equity up front.
   On the other hand, if you ask for more cash and less equity, it’s unlikely you’ll be able
   to negotiate to get more equity later on, since equity is increasingly scarce over time
@@ -1864,7 +1864,7 @@ grow quickly, a few other things are worth remembering when negotiating with sta
 - Negotiating title and exact details of your role early on may not matter as much in a
   small and growing company, because your role and the role of others may change a lot
   quickly. It’s more important that you respect the founders and leaders of the company.
-  It’s more important that you feel you are respected.
+  It’s more important that you feel [you are respected](https://blog.shrm.org/blog/respect-and-trust-top-the-list-of-most-important-employee-job-satisfaction).
 
 ### Typical employee equity levels
 
@@ -1918,19 +1918,19 @@ We’ll discuss negotiation strategies later on in this chapter, but keep in min
 everything we present here could come up in your negotiations.”
 
 Companies will always ask you what you want for compensation, and you should always be
-cautious about answering.
+[cautious about answering](http://review.chicagobooth.edu/strategy/2018/article/how-answer-one-toughest-interview-questions).
 If you name the lowest number you’ll accept, you can be pretty sure the company’s not
 going to exceed it, at least not by much.
 
 Some points on negotiating compensation:
 
-- Some argue that a good tactic in negotiating is to start higher than you will be willing
+- [Some argue](http://www.businessinsider.com/how-to-negotiate-make-first-offer-2014-5) that a good tactic in negotiating is to start higher than you will be willing
   to accept, so that the other party can “win” by negotiating you down a little bit.
   Keep in mind, this is just a suggested tactic, and not a hard and fast rule.
 - If you are inexperienced and are unsure what a fair offer should look like, avoid saying
   exactly what you want for compensation very early in discussions.
   It’s common for hiring managers or recruiters to ask this early in the process, just to
-  take advantage of candidates who don’t have a good sense of their own worth.
+  take advantage of candidates who don’t have a good sense of [their own worth](https://nuleadership.com/2018/01/08/know-your-worth-compensation-negotiation/).
   Tell them you want to focus on the opportunity as a whole and your ability to contribute
   before discussing numbers.
   Ask them to give you a fair offer once they understand your worth to the company.
@@ -1943,11 +1943,11 @@ Some points on negotiating compensation:
   agree what those could look like *if* you demonstrate outstanding performance and the
   company has money.
 - If you’re moving from an established company to a startup, you may be asked to take a
-  salary cut. This is reasonable, but it’s wise to discuss explicitly how much the cut is,
+  [salary cut](http://fortune.com/2016/06/13/new-job-pay-cut-leadership/). This is reasonable, but it’s wise to discuss explicitly how much the cut is,
   and when your salary will be renegotiated.
   For example, you might take 25% below your previous salary, but there can be an agreement
   that this will be corrected if your performance is strong and the company gets funding.
-- 🔹 Always negotiate non-compensation aspects before agreeing to an offer.
+- 🔹 Always negotiate [non-compensation aspects](http://time.com/money/4391908/job-offer-negotiations/) before agreeing to an offer.
   If you want a specific role, title, opportunity, visa sponsorship, parental leave, special
   treatment (like working from home), or have timing constraints about when you can join,
   negotiate these early, not late in the process.
@@ -1974,10 +1974,10 @@ Some notes on the negotiation process itself:
   [make no sense at all](https://erikbern.com/2016/03/16/exploding-offers-are-bullshit.html). If
   you are likely the best candidate for the position, or the role is a specialized and
   well-paid one where there are usually not enough good candidates to meet the demand,
-  you’ll likely have plenty of leverage to ask for more time, such as to complete the
+  you’ll likely have plenty of leverage to [ask for more time](http://www.businessinsider.com/how-to-politely-postpone-accepting-a-job-offer-2015-6#dont-be-afraid-to-negotiate-4), such as to complete the
   interview process with other companies.
   For example, software engineering roles in tech companies are like this currently.
-- Getting multiple offers is always in your interest.
+- Getting [multiple offers](https://www.themuse.com/advice/a-guide-to-juggling-multiple-job-offers-and-coming-out-on-top) is always in your interest.
   If you have competing offers, sharing the competing offers with the company you want to
   work for can be helpful, granted your offers are competitive.
   - However, dragging out negotiations excessively so you can “shop around” an offer to other
@@ -1986,7 +1986,7 @@ Some notes on the negotiation process itself:
 - ❗ Get all agreements in writing, if they are not in your offer letter.
 - **Reneging on offers**: Do not accept an offer verbally or in writing unless you’re ready to
   stand by your word.
-  In practice, people do occasionally accept an offer and then go back on it, or renege.
+  In practice, people do occasionally accept an offer and then go back on it, or [renege](https://purduecco.wordpress.com/2016/03/28/the-risks-of-reneging-on-a-job-offer/).
   This can put the company in a difficult position (they may have declined another key
   candidate based on your acceptance), and may hurt your reputation in unexpected ways
   later.
@@ -1996,7 +1996,7 @@ Some notes on the negotiation process itself:
 
 ### Offer and negotiation dangers
 
-To wind up our the discussion of offers and negotiations, here are some key dangers and
+To wind up our discussion of offers and negotiations, here are some key dangers and
 mistakes to watch out for:
 
 - ❗ Do not accept an offer of stock or shares without also asking for the exact number of

--- a/README.md
+++ b/README.md
@@ -1759,9 +1759,10 @@ However, this section covers some basics of what to expect with offers, and tips
 
 🔹 Companies can and should work hard to ensure that all candidates are
 [given equal treatment](https://rework.withgoogle.com/guides/pay-equity/steps/introduction/)
-in the hiring process.
-But candidates should also know their worth and understand that they can negotiate to get
-better offers.
+in the hiring process but
+[inequalities persist](https://iwpr.org/publications/gender-wage-gap-2017-race-ethnicity/).
+Candidates should know their worth and understand that they can negotiate to get better
+offers.
 
 - 🚧 Not sure what “roughly equal treatment” is meant to evoke.
   These would be the sections of this Guide to speak to the varied experiences of people who

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ### Why equity compensation matters
 
-**Equity compensation** is the granting of ownership in a company in exchange for work.
-In its ideal form, it aligns the interests of individual employees with the goals of a
-company, which can yield dramatic effects in creativity, team building, longevity of
+**Equity compensation** is the practice of granting ownership in a company in exchange for
+work. In its ideal form, it aligns the interests of individual employees with the goals of
+a company, which can yield dramatic effects in creativity, team building, longevity of
 employment, and in the creation of value—for the company, for its users and customers, and
 for the individuals who work to make it a success.
 
@@ -30,36 +30,37 @@ became public ([Financial Times](https://www.ft.com/content/d6599ae0-5738-11e1-8
 Unfortunately, the ways equity is granted for compensation, including
 [restricted stock, stock options, and restricted stock units](#how-equity-is-granted), are
 notoriously complex, with confounding terminology and high-stakes decisions.
-Talk to anyone who’s worked in startups and you’ll hear stories of how they or their
-colleagues met with the painful consequences of not learning enough up front.
+If you talk to enough employees and hiring managers, and you’ll hear stories of how they
+or their colleagues met with the painful consequences of not learning enough up front.
 How an individual negotiates their equity-based compensation or when they choose to make
-certain decisions, such as exercise stock options can have major *positive or negative*
+certain decisions, such as exercise stock options, can have **major positive or negative**
 financial outcomes.
 If a company fails, an employee may get no value at all for what they own in a company, or
 may lose money they paid for the stock or for taxes.
 Even if a company succeeds, an employee may fall into
-[catastrophic tax pitfalls](#tax-dangers) because they didn’t know they needed to file a piece
-of paper with the IRS.
+[catastrophic tax pitfalls](#tax-dangers) because they didn’t properly understand tax
+consequences.
 
 Many people learn the basic ideas of from personal experience or from colleagues or
 helpful friends who have been through it before.
 But it is well understood primarily by tax attorneys, corporate lawyers, and other
-[professionals](#seeking-professional-advice).
+[professionals](#seeking-professional-advice). Many are daunted by legalities and tax
+planning, a challenge even more acute when faced with a short window in which to make a
+key decision, like accept a job offer or exercise stock options.
 
 Although understanding the technicalities of equity compensation does not guarantee
 fortune will smile upon you as warmly as it did the early hires of Facebook, we do believe
 a good overview can help you [make better decisions](#offers-and-negotiations) and avoid some
-of the most common and [costly](#the-amt-trap) [mistakes](#tax-dangers). Many are daunted by
-legalities and tax planning, a challenge even more acute when faced with a short window in
-which to make a key decision, like accept a job offer or exercise stock options.
+of the most common and [costly](#the-amt-trap) [mistakes](#tax-dangers).
 
 ### When equity compensation applies
 
-Generally, equity compensation is closely linked to **growth of a company**. Cash-poor
-startups persuade early employees to take pay cuts and join their team by offering
-[meaningful ownerships stakes](#typical-employee-equity-levels), catering to hopes that the
-company will one day grow large enough to [go public or sell](#ipos-sales-and-liquidity) for
-an ample sum. And large, fast-growing companies find offering compensation linked to
+Generally, equity compensation is closely linked to **growth** of a company.
+Cash-poor startups persuade early employees to take pay cuts and join their team by
+offering [meaningful ownerships stakes](#typical-employee-equity-levels), catering to hopes
+that the company will one day grow large enough to
+[go public or sell](#ipos-sales-and-liquidity) for an ample sum.
+More mature but still fast-growing companies find offering compensation linked to
 ownership is more attractive than cash to many candidates.
 
 With the hope for growth, however, also comes **risk**. According to
@@ -85,26 +86,26 @@ Fig. 2).
 
 ### Why this Guide?
 
-Because you shouldn’t need a law degree or MBA to understand how you are paid.
-Because you shouldn’t have to know a lawyer or tax professional to orient yourself on the
-subject. Because you shouldn’t have to fail before you succeed.
-
 We have created this Guide to help everyone get a fair shake, understand their decisions,
 and save time and effort.
+Although it is far from perfect, and still improving, a significant number of experts,
+editors, authors have worked to assemble and review it.
+
+We believe you shouldn’t need a law degree or MBA to understand how you are paid.
+You shouldn’t have to know a lawyer or tax professional to orient yourself on the subject.
+And you shouldn’t have to fail before you succeed.
 
 While [a lot of information](#further-reading) on this topic is just a Google search away,
-the best information is scattered about.
+the best resources are scattered about.
 Many blogs and articles focus only on a narrow topic, are getting older, or are on sites
 supported by ads or other products.
 In contrast, this Guide is written to be:
 
-- **Reliable**: It is not written to promote any investor, company, or product.
-  Although it is far from perfect, and still improving, a significant number of experts,
-  editors, authors have worked to assemble and review it.
+- **Reliable**: We do not promote any investor, company, or product.
   We link liberally, so you can get more detail and other perspectives.
 - **Clear**: We keep things brief and clear, but don’t over-simplify.
 - **Practical**: We include concrete details, advice, and pitfalls.
-- **Thoughtful**: We try to give context where we can.
+- **Thoughtful**: We try to give context around the dry topic.
   Some issues are also controversial or just confusing, and we work to cover points of view
   from multiple experts when they differ.
 - **Living**: We will keep updating this material, and [welcome your contributions](#please-help)!
@@ -324,11 +325,6 @@ compensation.
     company.
   - 🚧 Groundwork:
     What are good stats on how many people work in startups vs established companies?
-- Companies involve many people, so it’s important to track how much of the company each
-  person owns, so that future profits are divided appropriately.
-  Historically, this has been done a few ways, depending on the size and nature of the
-  company. One way to do this, especially when a lot of people are involved, is via stock,
-  which we’ll get into next.
 - Companies in the US include sole proprietorships, partnerships, limited liability
   companies (LLCs), S corporations, and C corporations.
   - 🔸 This Guide does not cover equity compensation in LLCs, as they are rarely used as the
@@ -347,25 +343,18 @@ compensation.
   [reasons](https://www.quora.com/Why-do-most-technology-startups-incorporate-in-Delaware),
   these companies are usually formed in Delaware, so legalities of all this are defined in
   Delaware law.
+- Loosely, one way to think about all this is that a company is a set of contracts,
+  negotiated over time between people and enforced by the government, that align interests
+  of a group of people in creating things customers are willing to pay for.
+  A key part of these contacts is precisely tracking ownership.
+  Historically, this has been done a few ways, depending on the size and nature of the
+  company, but possibly the most effective way when a lot of people are involved, is via
+  stock, which we get into next.
+- 🚧 Mention how court cases are settled?
 - 🚧 Define board of directors.
+- 🚧 Define cap table.
 
-### Public and private companies
-
-- 🄳 [**Public companies**](https://en.wikipedia.org/wiki/Public_company) are corporations where
-  any member of the public can own stock.
-  People can buy and sell the stock for cash on public
-  [exchanges](https://www.investopedia.com/terms/e/exchange.asp). The value of a company’s
-  shares is the value you see in the stock market reports, so shareholders know how much
-  their stock is worth.
-- 🄳 Most smaller companies, including all startups, are
-  [**private companies**](https://en.wikipedia.org/wiki/Privately_held_company) with owners who
-  control how those companies operate.
-  Unlike a public company, where anyone is able to buy and sell stock, owners of a private
-  company control who is able to buy and sell their stock.
-  There may be few or no transactions, or they may not be publicly known.
-- 🚧 What are public exchanges and how stock is bought and sold in practice?
-
-### What is stock?
+### Stock and shares
 
 - 🄳 [**Stock**](https://en.wikipedia.org/wiki/Stock) is a legal invention that helps track
   ownership of a company.
@@ -402,34 +391,49 @@ compensation.
   Even if you have a fixed number of shares, your percentage ownership will change over time
   as the outstanding shares change.
 
-### What is equity?
-
-🚧 Structure: Intro on how equity is broader than just stock.
+### Equity
 
 🄳 We say you have **equity** in a company when you have some kind of ownership or likely
 future ownership.
-It can take many forms in practice, so may include restricted stock, stock options, and
-RSUs, which we’ll be discussing at length.
+For purposes of compensation, people are very rarely granted stock with no strings
+attached. Instead, they’re given stock with additional restrictions placed on it, or
+contractual rights that later can lead to owning stock.
+Examples include [restricted stock, stock options, and RSUs](#how-equity-is-granted)
 
 ☝️ The word “equity” has
 [several technical meanings](https://www.investopedia.com/terms/e/equity.asp) in accounting
 and other financial contexts, but when we talk about equity compensation, it refers to
 ownership in a company you work for.
 
+### Public and private companies
+
+- 🄳 [**Public companies**](https://en.wikipedia.org/wiki/Public_company) are corporations where
+  any member of the public can own stock.
+  People can buy and sell the stock for cash on public
+  [exchanges](https://www.investopedia.com/terms/e/exchange.asp). The value of a company’s
+  shares is the value you see in the stock market reports, so shareholders know how much
+  their stock is worth.
+- 🄳 Most smaller companies, including all startups, are
+  [**private companies**](https://en.wikipedia.org/wiki/Privately_held_company) with owners who
+  control how those companies operate.
+  Unlike a public company, where anyone is able to buy and sell stock, owners of a private
+  company control who is able to buy and sell their stock.
+  There may be few or no transactions, or they may not be publicly known.
+- 🚧 What are public exchanges and how stock is bought and sold in practice?
+
 ### Fundraising, growth, and dilution
 
-🚧 Structure: Intro on how this applies to earlier and growing companies.
+Many large and successful companies have begun as startups, and in general startups rely
+on investors to help fund more rapid growth.
 
-🄳 In order to finance a new company, startups **fundraise** by selling shares in their
-business to [investors](http://www.investopedia.com/terms/i/investor.asp) in exchange for
-capital. For startups that aspire to grow rapidly, it’s likely they will fundraise from
-investors called **venture capitalists**.
+🄳 In order to finance building or scaling their business, startups **fundraise** by selling
+shares in their business to [investors](http://www.investopedia.com/terms/i/investor.asp) in
+exchange for capital.
+For startups that aspire to grow rapidly, it’s likely they will fundraise from investors
+called **venture capitalists**.
 
 A startup goes through [several stages of growth](#stages-of-a-startup) as it fundraises
 based on evidence that it will make money in the future.
-
-At the other end of the spectrum from early stage startups are large, established
-companies.
 
 - 🄳 As these companies add (or “issue”) stock, the outstanding shares goes up, and the
   percentage ownership of each shareholder goes down.
@@ -460,13 +464,11 @@ companies.
   certain kinds of shares become worthless while other kinds have some value.
 
 🚧 How do larger companies think about stock, growth, and equity compensation?
-
 🚧 Infographic:
 Dilution and growing equity value.
 
-### How startups grow or fail
+### Stages of a startup
 
-Many large and successful companies have begun as startups.
 Understanding stock and equity value in a startup requires understanding the stages of a
 startup’s growth and how that affects who owns the stock.
 
@@ -491,18 +493,16 @@ startup’s growth and how that affects who owns the stock.
   - **Series C, D, E, etc.**
     (tens to hundreds of millions): Continued scaling of the business.
 - 🔸 Most startups don’t get far.
-  Very roughly, if you
-  [look at angel investments](http://codingvc.com/valuing-employee-options/), **more than half**
-  of investments fail, **one in 3** are small successes (1X to 5X returns), **one in 8** are
-  big successes (5X to 30x), and **one in 20** are huge successes (30X+).
+  According [one analysis](http://codingvc.com/valuing-employee-options/) by
+  [Leo Polovets](http://codingvc.com), if you look angel investments, the earliest and smallest
+  kind of investment, roughly **more than half** of investments fail, **one in 3** are small
+  successes (1X to 5X returns), **one in 8** are big successes (5X to 30x), and **one in 20**
+  are huge successes (30X+).
   - 🚧 Can we get better stats beyond angel investments?
 - 🔸 Each stage reflects the removal of risk and increased dilution.
   For this reason, the equity team members get is higher in the earlier stages (starting
   with founders) and increasingly lower as a company matures.
   (See the picture above.)
-- 🔹 It is critical to understand risk and dilution to know the possible future value of
-  equity. [This article](http://codingvc.com/valuing-employee-options/) from Leo Polovets, a
-  partner at Susa Ventures, gives a good overview.
 
 ### Counting shares
 
@@ -842,7 +842,7 @@ you are **exercising** the options.
 
 ☝️ **“Stock options” is a confusing term.**
 In investment, an *option* is a right (but not an obligation) to buy something at a
-certain price at within some time frame.
+certain price within some time frame.
 You’ll often
 [see “stock options” discussed](https://www.investopedia.com/terms/s/stockoption.asp) in the
 context of investment.
@@ -1596,13 +1596,10 @@ includes equity compensation, or to evaluate equity you currently have in a comp
   Typically, this number is presented in percent or **basis points** (hundredths of a
   percent). Some companies don’t volunteer this information unless you specifically ask, but
   it’s always a fair question, since without it, the offer of shares is almost meaningless.
-
-- 🚧 This is all sounding more and more like the roadmap we need to the whole Guide.
-  “These are the fundamental concepts in equity compensation that we’ll map out in much
-  greater detail in the rest of the Guide.”
-  This is basically a summary of everything we’ve already learned, except now we’re told why
-  it’s really important to know all of those details and how they fit together into the
-  whole picture actionable picture, which is indeed evaluating equity compensation.
+- 🔹 It is critical to understand [dilution](#fundraising-growth-and-dilution) and
+  [risk](#stages-of-a-startup) to know the possible future value of equity for the company and
+  its stage. [This article](http://codingvc.com/valuing-employee-options/) from Leo Polovets
+  provides a thoughtful overview.
 
 ### Dangers evaluating equity compensation
 


### PR DESCRIPTION
Added remaining links to Offers and Negotiations. There are a few more items I'd like to link out from in the text but researching them is proving time-consuming, so I'll stop on this section for now.

Linked sample documents to all the items mentioned in the Documents and Agreements Section. All accounted for though a couple (409a, 83(b)) are not ideal. See commit notes.

Made two minor editorial changes. One to tone down the statement that recruiters and hiring managers are commonly trying to trick candidates, and two to rework and add a link to the statement about equal treatment in hiring (to acknowledge that it's not that equal).