### PR TITLE
Hope further reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -2684,7 +2684,7 @@ It’s not exhaustive, as titles and details vary.
 
     ## Further Reading
 
-    - **Introductory resources**
+    - **General resources**
       - Mark P. Cussen, Investopedia,
         [*Introduction To Incentive Stock Options*](http://www.investopedia.com/articles/stocks/12/introduction-incentive-stock-options.asp),
         updated 2017\.
@@ -2704,16 +2704,20 @@ It’s not exhaustive, as titles and details vary.
         [*Employee Stock Options: Definitions and Key Concepts*](http://www.investopedia.com/university/employee-stock-options-eso/eso1.asp).
     - **Considerations for founders**
       -  Matthew Bartus, Cooley GO,
-      [*Option Grants: Fully Diluted or Issued and Outstanding*](https://www.cooleygo.com/option-grants-fully-diluted-issued-outstanding/).
+        [*Option Grants: Fully Diluted or Issued and Outstanding*](https://www.cooleygo.com/option-grants-fully-diluted-issued-outstanding/).
       - Jay Bhatti, Business Insider,
-      [*How Startups Should Deal With Cliff Vesting For Employees*](http://www.businessinsider.com/everything-you-need-to-know-about-cliff-vesting-2011-5),
+        [*How Startups Should Deal With Cliff Vesting For Employees*](http://www.businessinsider.com/everything-you-need-to-know-about-cliff-vesting-2011-5),
       2011\.
-      - Babak Nivi, [*The Option Pool Shuffle*](http://venturehacks.com/articles/option-pool-shuffle)
+      - Tahir J. Naim, Fenwick,
+        [*Section 409A Valuations and Stock Option Grants for Start-up Technology and Life Science Companies*](http://www.fenwick.com/FenwickDocuments/409_Valuations_Stock_Options.pdf).
+      - Babak Nivi, Venture Hacks [*The Option Pool Shuffle*](http://venturehacks.com/articles/option-pool-shuffle)
       (and [table of equity](http://venturehacks.com/articles/option-pool-shuffle#market) ranges), 2017\.
       - Leo Polovets,
       [*Analyzing AngelList Job Postings, Part 2: Salary and Equity Benchmarks*](http://codingvc.com/analyzing-angellist-job-postings-part-2-salary-and-equity-benchmarks), 2014\.
+      - Scott Edward Walker, VentureBeat,
+      [*Beware the trappings of liquidation preference*](http://venturebeat.com/2010/08/16/beware-the-trappings-of-liquidation-preference/), 2010\.
       - Joe Wallin, The Startup Law Blog,[*Top 6 Reasons To Grant NQOs Over ISOs*](http://www.startuplawblog.com/2010/08/11/top-reasons-nqos-over-isos/), 2010\.
-      - Clerky, [*Legal Concepts for Founders*](https://handbook.clerky.com/).     
+      - Clerky, [*Legal Concepts for Founders*](https://handbook.clerky.com/).    
     - **Considerations for candidates and employees**
       - Anonymous,
         [*What I Wish I’d Known About Equity Before Joining A Unicorn*](https://gist.github.com/yossorion/4965df74fd6da6cdc280ec57e83a202d),
@@ -2753,10 +2757,16 @@ It’s not exhaustive, as titles and details vary.
       - Joe Wallin,
       [*RSUs vs. Restricted Stock vs. Stock Options*](http://joewallin.com/2014/09/13/rsus-vs-restricted-stock-vs-stock-options/), 2014\.
     - **Taxes**
-      - Mark P. Cussen, Investopedia,[*How Restricted Stock And RSUs Are Taxed*](http://www.investopedia.com/articles/tax/09/restricted-stock-tax.asp?performancelayout=true).
+      - Steven Ayre, Accelerated Vesting,
+      [*What Is An 83(b) Election and When Do I Make It?*](http://acceleratedvesting.com/what-is-an-83b-election-and-when-do-i-make-it-part-1-with-graphic/),
+      2013\.
+      - Mark P. Cussen, Investopedia, [*How Restricted Stock And RSUs Are Taxed*](http://www.investopedia.com/articles/tax/09/restricted-stock-tax.asp?performancelayout=true).
       - Barry Kramer,
         [🔑*The Tax Law that is (Unintentionally) Hammering Silicon Valley Employees*](https://medium.com/@barryjk/the-tax-law-that-is-unintentionally-hammering-silicon-valley-employees-894a7b54ba8a),
         2015\.
+      - Joshua Levy and Joe Wallin, The Startup Law Blog,
+          [*The Problem With Immediately Exercisable ISOs*](http://thestartuplawblog.com/the-problem-with-immediately-exercisable-isos/),
+          2015\.
       - Kaye A. Thomas, Fairmark,
         [*AMT and Long-Term Capital Gain*](http://fairmark.com/general-taxation/alternative-minimum-tax/amt-long-term-capital-gain/),
         2014\.
@@ -2765,28 +2775,19 @@ It’s not exhaustive, as titles and details vary.
         2010\.
       - NCEO,
         [*Stock Options and the Alternative Minimum Tax (AMT)*](https://www.nceo.org/articles/stock-options-alternative-minimum-tax-amt)
-    - **Specialized topics**
-      - Steven Ayre, Accelerated Vesting,
-        [*What Is An 83(b) Election and When Do I Make It?*](http://acceleratedvesting.com/what-is-an-83b-election-and-when-do-i-make-it-part-1-with-graphic/),
-        2013\.
-      - Joshua Levy and Joe Wallin, The Startup Law Blog,
-        [*The Problem With Immediately Exercisable ISOs*](http://thestartuplawblog.com/the-problem-with-immediately-exercisable-isos/),
-        2015\.
-      - Tahir J. Naim, Fenwick,
-        [*Section 409A Valuations and Stock Option Grants for Start-up Technology and Life Science Companies*](http://www.fenwick.com/FenwickDocuments/409_Valuations_Stock_Options.pdf).
+    - **Vesting and expiration of stock options**
       - Babak Nivi, Venture Hacks,
-        [*How to make a cap table*](http://venturehacks.com/articles/cap-table), 2007\.
+      [*How to make a cap table*](http://venturehacks.com/articles/cap-table), 2007\.
       - Mary Russell, Stock Option Counsel,
       [*Can the Company Take Back My Vested Shares?*](http://stockoptioncounsel.com/blog/standards-ownership-canthecomanytakebackmyvestedshares), 2017\.
+      - Mary Russell, Stock Option Counsel, [*Early Expiration of Startup Stock Options - Part 1 - A $1 Million Problem*](http://stockoptioncounsel.com/blog/nc7go8ivzxb1el5rhv6nltrjan0n2t/2017/3/6), 2017\.
       - Mary Russell, Stock Option Counsel,
-      [*Early Expiration of Startup Stock Options - Part 2 -The Full 10-Year Term Solution*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-2-the-full-10-year-term-solution/2017/3/28),
-      2017\.
+     [*Early Expiration of Startup Stock Options - Part 2 -The Full 10-Year Term Solution*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-2-the-full-10-year-term-solution/2017/3/28),
+     2017\.
       - Mary Russell, Stock Option Counsel,
-      [*Early Expiration of Startup Stock Options - Part 3 - Examples of Good Equity Design by Company Stage*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-3-examples-of-good-startup-equity-design-by-company-stage/2017/8/11),
-      2017\.
+     [*Early Expiration of Startup Stock Options - Part 3 - Examples of Good Equity Design by Company Stage*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-3-examples-of-good-startup-equity-design-by-company-stage/2017/8/11),
+     2017\.
       - Dan Shapiro, [*Vesting is a hack*](http://www.danshapiro.com/blog/2012/04/vesting-is-a-hack/), 2012\.
-      - Scott Edward Walker, VentureBeat,
-      [*Beware the trappings of liquidation preference*](http://venturebeat.com/2010/08/16/beware-the-trappings-of-liquidation-preference/), 2010\.
     - **Forms and tools**
       - [🔨TLDR Stock Options](https://tldroptions.io/) and [OwnYourVenture](http://ownyourventure.com/)
         are simulators illustrating equity calculations and dilution

--- a/README.md
+++ b/README.md
@@ -2687,7 +2687,7 @@ It’s not exhaustive, as titles and details vary.
     - **Introductory resources**
       - Mark P. Cussen, Investopedia,
         [*Introduction To Incentive Stock Options*](http://www.investopedia.com/articles/stocks/12/introduction-incentive-stock-options.asp),
-        updated 2017.
+        updated 2017\.
       - Alex MacCaw,
         [*An Engineer’s Guide to Stock Options*](http://blog.alexmaccaw.com/an-engineers-guide-to-stock-options),
         2013\.
@@ -2701,7 +2701,19 @@ It’s not exhaustive, as titles and details vary.
         [ 💰*An Introduction to Stock & Options for the Tech Entrepreneur or Startup Employee*](https://www.scribd.com/doc/55945011/An-Introduction-to-Stock-Options-for-the-Tech-Entrepreneur-or-Startup-Employee#scribd),
         2012\.
       - Investopedia,
-        [*Employee Stock Options: Definitions and Key Concepts*](http://www.investopedia.com/university/employee-stock-options-eso/eso1.asp)
+        [*Employee Stock Options: Definitions and Key Concepts*](http://www.investopedia.com/university/employee-stock-options-eso/eso1.asp).
+    - **Considerations for founders**
+     -  Matthew Bartus, Cooley GO,
+      [*Option Grants: Fully Diluted or Issued and Outstanding*](https://www.cooleygo.com/option-grants-fully-diluted-issued-outstanding/).
+     - Jay Bhatti, Business Insider,
+      [*How Startups Should Deal With Cliff Vesting For Employees*](http://www.businessinsider.com/everything-you-need-to-know-about-cliff-vesting-2011-5),
+      2011\.
+     - Babak Nivi, [*The Option Pool Shuffle*](http://venturehacks.com/articles/option-pool-shuffle)
+      (and [table of equity](http://venturehacks.com/articles/option-pool-shuffle#market) ranges), 2017\.
+     - Leo Polovets,
+      [*Analyzing AngelList Job Postings, Part 2: Salary and Equity Benchmarks*](http://codingvc.com/analyzing-angellist-job-postings-part-2-salary-and-equity-benchmarks), 2014\.
+     - Joe Wallin, The Startup Law Blog,[*Top 6 Reasons To Grant NQOs Over ISOs*](http://www.startuplawblog.com/2010/08/11/top-reasons-nqos-over-isos/), 2010\.
+      - Clerky, [*Legal Concepts for Founders*](https://handbook.clerky.com/).
     - **Considerations for candidates and employees**
       - Anonymous,
         [*What I Wish I’d Known About Equity Before Joining A Unicorn*](https://gist.github.com/yossorion/4965df74fd6da6cdc280ec57e83a202d),
@@ -2717,12 +2729,11 @@ It’s not exhaustive, as titles and details vary.
         2013\.
       - Guy Kawasaki, [*Nine Questions to Ask a Startup*](http://guykawasaki.com/nine_questions_/),
         2006\.
-        Added
-      - Maria Konnikova, the New Yorker [*Lean Out: The Dangers for Women who Negotiate*](https://www.newyorker.com/science/maria-konnikova/lean-out-the-dangers-for-women-who-negotiate)
-      - Eileen Patten, Pew Research Center, [*Racial, gender wage gaps persist in U.S. despite some progress*](http://www.pewresearch.org/fact-tank/2016/07/01/racial-gender-wage-gaps-persist-in-u-s-despite-some-progress/), 2016.
-      - Leo Polovets,
-        [*Analyzing AngelList Job Postings, Part 2: Salary and Equity Benchmarks*](http://codingvc.com/analyzing-angellist-job-postings-part-2-salary-and-equity-benchmarks),
-        2014\.
+      - Maria Konnikova, the New Yorker
+        [*Lean Out: The Dangers for Women who Negotiate*](https://www.newyorker.com/science/maria-konnikova/lean-out-the-dangers-for-women-who-negotiate)
+      - Eileen Patten, Pew Research Center,
+        [*Racial, gender wage gaps persist in U.S. despite some progress*](http://www.pewresearch.org/fact-tank/2016/07/01/racial-gender-wage-gaps-persist-in-u-s-despite-some-progress/),
+        2016\.
       - Leo Polovets, [*Valuing Employee Options*](http://codingvc.com/valuing-employee-options/),
         2015\.
       - Andy Rachleff, Wealthfront,
@@ -2732,18 +2743,15 @@ It’s not exhaustive, as titles and details vary.
         [*5 Mistakes You Can’t Afford to Make with Stock Options*](https://gigaom.com/2011/06/05/5-mistakes-you-cant-afford-to-make-with-stock-options/),
         2011\.
     - **Types of equity compensation**
-     - Jeron Paul, Capshare, [*RSUs vs. Options: Why RSUs (Restricted Stock Units) Could be Better Than Stock Options At Your Private Company*](https://www.capshare.com/blog/rsus-vs-options/), 2016.
+     - Jeron Paul, Capshare,
+      [*RSUs vs. Options: Why RSUs (Restricted Stock Units) Could be Better Than Stock Options At Your Private Company*](https://www.capshare.com/blog/rsus-vs-options/),
+      2016\.
      - Andy Rachleff, Wealthfront,
-        [*How Do Stock Options and RSUs Differ?*](https://blog.wealthfront.com/stock-options-versus-rsu/),
-        2014\.
-      - Joe Wallin, The Startup Law Blog,
-        [*Incentive Stock Options vs. Nonqualified Stock Options*](http://www.startuplawblog.com/2013/05/15/incentive-stock-options-vs-nonqualified-stock-options/),
-        2013\.
-      - Joe Wallin,
-        [*RSUs vs. Restricted Stock vs. Stock Options*](http://joewallin.com/2014/09/13/rsus-vs-restricted-stock-vs-stock-options/),
-        2014\.
-      - Joe Wallin, The Startup Law Blog,[*Top 6 Reasons To Grant NQOs Over ISOs*](http://www.startuplawblog.com/2010/08/11/top-reasons-nqos-over-isos/),
-        2010\.
+      [*How Do Stock Options and RSUs Differ?*](https://blog.wealthfront.com/stock-options-versus-rsu/), 2014\.
+     - Joe Wallin, The Startup Law Blog,
+      [*Incentive Stock Options vs. Nonqualified Stock Options*](http://www.startuplawblog.com/2013/05/15/incentive-stock-options-vs-nonqualified-stock-options/), 2013\.
+     - Joe Wallin,
+      [*RSUs vs. Restricted Stock vs. Stock Options*](http://joewallin.com/2014/09/13/rsus-vs-restricted-stock-vs-stock-options/), 2014\.
     - **Taxes**
       - Mark P. Cussen, Investopedia,[*How Restricted Stock And RSUs Are Taxed*](http://www.investopedia.com/articles/tax/09/restricted-stock-tax.asp?performancelayout=true).
       - Barry Kramer,
@@ -2761,29 +2769,24 @@ It’s not exhaustive, as titles and details vary.
       - Steven Ayre, Accelerated Vesting,
         [*What Is An 83(b) Election and When Do I Make It?*](http://acceleratedvesting.com/what-is-an-83b-election-and-when-do-i-make-it-part-1-with-graphic/),
         2013\.
-      - Matthew Bartus, Cooley GO,
-        [*Option Grants: Fully Diluted or Issued and Outstanding*](https://www.cooleygo.com/option-grants-fully-diluted-issued-outstanding/).
-      - Jay Bhatti, Business Insider, [*How Startups Should Deal With Cliff Vesting For Employees*](http://www.businessinsider.com/everything-you-need-to-know-about-cliff-vesting-2011-5), 2011.
       - Joshua Levy and Joe Wallin, The Startup Law Blog,
         [*The Problem With Immediately Exercisable ISOs*](http://thestartuplawblog.com/the-problem-with-immediately-exercisable-isos/),
         2015\.
       - Tahir J. Naim, Fenwick,
         [*Section 409A Valuations and Stock Option Grants for Start-up Technology and Life Science Companies*](http://www.fenwick.com/FenwickDocuments/409_Valuations_Stock_Options.pdf).
       - Babak Nivi, Venture Hacks,
-        [*How to make a cap table*](http://venturehacks.com/articles/cap-table), 2007.
-      - Babak Nivi, [*The Option Pool Shuffle*](http://venturehacks.com/articles/option-pool-shuffle)
-        (and [table of equity](http://venturehacks.com/articles/option-pool-shuffle#market) ranges),
-        2017\.
-     - Mary Russell, Stock Option Counsel,
-        [*Can the Company Take Back My Vested Shares?*](http://stockoptioncounsel.com/blog/standards-ownership-canthecomanytakebackmyvestedshares),
-        2017\.
-     - Mary Russell, Stock Option Counsel, [*Early Expiration of Startup Stock Options - Part 2 -The Full 10-Year Term Solution*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-2-the-full-10-year-term-solution/2017/3/28), 2017.   
-     - Mary Russell, Stock Option Counsel, [*Early Expiration of Startup Stock Options - Part 3 - Examples of Good Equity Design by Company Stage*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-3-examples-of-good-startup-equity-design-by-company-stage/2017/8/11), 2017.
-      - Dan Shapiro, [*Vesting is a hack*](http://www.danshapiro.com/blog/2012/04/vesting-is-a-hack/),
-        2012\.
+        [*How to make a cap table*](http://venturehacks.com/articles/cap-table), 2007\.
+      - Mary Russell, Stock Option Counsel,
+      [*Can the Company Take Back My Vested Shares?*](http://stockoptioncounsel.com/blog/standards-ownership-canthecomanytakebackmyvestedshares), 2017\.
+      - Mary Russell, Stock Option Counsel,
+      [*Early Expiration of Startup Stock Options - Part 2 -The Full 10-Year Term Solution*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-2-the-full-10-year-term-solution/2017/3/28),
+      2017\.
+      - Mary Russell, Stock Option Counsel,
+      [*Early Expiration of Startup Stock Options - Part 3 - Examples of Good Equity Design by Company Stage*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-3-examples-of-good-startup-equity-design-by-company-stage/2017/8/11),
+      2017\.
+      - Dan Shapiro, [*Vesting is a hack*](http://www.danshapiro.com/blog/2012/04/vesting-is-a-hack/), 2012\.
       - Scott Edward Walker, VentureBeat,
-        [*Beware the trappings of liquidation preference*](http://venturebeat.com/2010/08/16/beware-the-trappings-of-liquidation-preference/),
-        2010\.
+      [*Beware the trappings of liquidation preference*](http://venturebeat.com/2010/08/16/beware-the-trappings-of-liquidation-preference/), 2010\.
     - **Forms and tools**
       - [🔨TLDR Stock Options](https://tldroptions.io/) and [OwnYourVenture](http://ownyourventure.com/)
         are simulators illustrating equity calculations and dilution

--- a/README.md
+++ b/README.md
@@ -2691,7 +2691,8 @@ It’s not exhaustive, as titles and details vary.
       - Alex MacCaw,
         [*An Engineer’s Guide to Stock Options*](http://blog.alexmaccaw.com/an-engineers-guide-to-stock-options),
         2013\.
-      - Andy Rachleff, Wealthfront,[*The 14 Crucial Questions about Stock Options*](https://blog.wealthfront.com/stock-options-14-crucial-questions/),
+      - Andy Rachleff, Wealthfront,
+        [*The 14 Crucial Questions about Stock Options*](https://blog.wealthfront.com/stock-options-14-crucial-questions),
         2014\.
       - Mary Russell, Stock Option Counsel,
         [*Startup Equity Standards: A Guide for Employees*](http://www.slideshare.net/StockOptionCnsl/startup-standards-stock-option-counsel),
@@ -2728,7 +2729,8 @@ It’s not exhaustive, as titles and details vary.
         [*5 Mistakes You Can’t Afford to Make with Stock Options*](https://gigaom.com/2011/06/05/5-mistakes-you-cant-afford-to-make-with-stock-options/),
         2011\.
     - **Types of equity compensation**
-      - Andy Rachleff, Wealthfront,[*How Do Stock Options and RSUs Differ?*](https://blog.wealthfront.com/stock-options-versus-rsu/),
+      - Andy Rachleff, Wealthfront,
+        [*How Do Stock Options and RSUs Differ?*](https://blog.wealthfront.com/stock-options-versus-rsu/),
         2014\.
       - Joe Wallin, The Startup Law Blog,
         [*Incentive Stock Options vs. Nonqualified Stock Options*](http://www.startuplawblog.com/2013/05/15/incentive-stock-options-vs-nonqualified-stock-options/),
@@ -2756,7 +2758,7 @@ It’s not exhaustive, as titles and details vary.
         [*What Is An 83(b) Election and When Do I Make It?*](http://acceleratedvesting.com/what-is-an-83b-election-and-when-do-i-make-it-part-1-with-graphic/),
         2013\.
       - Matthew Bartus, Cooley GO,
-        [*Option Grants: Fully Diluted or Issued and Outstanding*](https://www.cooleygo.com/option-grants-fully-diluted-issued-outstanding/)
+        [*Option Grants: Fully Diluted or Issued and Outstanding*](https://www.cooleygo.com/option-grants-fully-diluted-issued-outstanding/).
       - Joshua Levy and Joe Wallin, The Startup Law Blog,
         [\*The Problem With Immediately Exercisable ISOs](http://thestartuplawblog.com/the-problem-with-immediately-exercisable-isos/),
         2015\.

--- a/README.md
+++ b/README.md
@@ -2717,6 +2717,9 @@ It’s not exhaustive, as titles and details vary.
         2013\.
       - Guy Kawasaki, [*Nine Questions to Ask a Startup*](http://guykawasaki.com/nine_questions_/),
         2006\.
+        Added
+      - Maria Konnikova, the New Yorker [*Lean Out: The Dangers for Women who Negotiate*](https://www.newyorker.com/science/maria-konnikova/lean-out-the-dangers-for-women-who-negotiate)
+      - Eileen Patten, Pew Research Center, [*Racial, gender wage gaps persist in U.S. despite some progress*](http://www.pewresearch.org/fact-tank/2016/07/01/racial-gender-wage-gaps-persist-in-u-s-despite-some-progress/), 2016.
       - Leo Polovets,
         [*Analyzing AngelList Job Postings, Part 2: Salary and Equity Benchmarks*](http://codingvc.com/analyzing-angellist-job-postings-part-2-salary-and-equity-benchmarks),
         2014\.
@@ -2729,7 +2732,8 @@ It’s not exhaustive, as titles and details vary.
         [*5 Mistakes You Can’t Afford to Make with Stock Options*](https://gigaom.com/2011/06/05/5-mistakes-you-cant-afford-to-make-with-stock-options/),
         2011\.
     - **Types of equity compensation**
-      - Andy Rachleff, Wealthfront,
+     - Jeron Paul, Capshare, [*RSUs vs. Options: Why RSUs (Restricted Stock Units) Could be Better Than Stock Options At Your Private Company*](https://www.capshare.com/blog/rsus-vs-options/), 2016.
+     - Andy Rachleff, Wealthfront,
         [*How Do Stock Options and RSUs Differ?*](https://blog.wealthfront.com/stock-options-versus-rsu/),
         2014\.
       - Joe Wallin, The Startup Law Blog,
@@ -2759,8 +2763,9 @@ It’s not exhaustive, as titles and details vary.
         2013\.
       - Matthew Bartus, Cooley GO,
         [*Option Grants: Fully Diluted or Issued and Outstanding*](https://www.cooleygo.com/option-grants-fully-diluted-issued-outstanding/).
+      - Jay Bhatti, Business Insider, [*How Startups Should Deal With Cliff Vesting For Employees*](http://www.businessinsider.com/everything-you-need-to-know-about-cliff-vesting-2011-5), 2011.
       - Joshua Levy and Joe Wallin, The Startup Law Blog,
-        [\*The Problem With Immediately Exercisable ISOs](http://thestartuplawblog.com/the-problem-with-immediately-exercisable-isos/),
+        [*The Problem With Immediately Exercisable ISOs*](http://thestartuplawblog.com/the-problem-with-immediately-exercisable-isos/),
         2015\.
       - Tahir J. Naim, Fenwick,
         [*Section 409A Valuations and Stock Option Grants for Start-up Technology and Life Science Companies*](http://www.fenwick.com/FenwickDocuments/409_Valuations_Stock_Options.pdf).
@@ -2769,9 +2774,11 @@ It’s not exhaustive, as titles and details vary.
       - Babak Nivi, [*The Option Pool Shuffle*](http://venturehacks.com/articles/option-pool-shuffle)
         (and [table of equity](http://venturehacks.com/articles/option-pool-shuffle#market) ranges),
         2017\.
-      - Mary Russell, Stock Option Counsel,
+     - Mary Russell, Stock Option Counsel,
         [*Can the Company Take Back My Vested Shares?*](http://stockoptioncounsel.com/blog/standards-ownership-canthecomanytakebackmyvestedshares),
         2017\.
+     - Mary Russell, Stock Option Counsel, [*Early Expiration of Startup Stock Options - Part 2 -The Full 10-Year Term Solution*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-2-the-full-10-year-term-solution/2017/3/28), 2017.   
+     - Mary Russell, Stock Option Counsel, [*Early Expiration of Startup Stock Options - Part 3 - Examples of Good Equity Design by Company Stage*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-3-examples-of-good-startup-equity-design-by-company-stage/2017/8/11), 2017.
       - Dan Shapiro, [*Vesting is a hack*](http://www.danshapiro.com/blog/2012/04/vesting-is-a-hack/),
         2012\.
       - Scott Edward Walker, VentureBeat,

--- a/README.md
+++ b/README.md
@@ -2678,77 +2678,108 @@ It’s not exhaustive, as titles and details vary.
   - Instructions and template for early exercise and 📥[83(b) election](https://www.irs.gov/pub/irs-drop/rp-12-29.pdf),
     if applicable
 - End of year tax documents
+
   - You should receive a form 📥[3921 or 3922](https://www.irs.gov/uac/form-3921-exercise-of-an-incentive-stock-option-under-section-422-b)
     from your company if you exercised ISO options during the year.
 
-## Further Reading
+    ## Further Reading
 
-- David Weekly,
-  [An Introduction to Stock & Options for the Tech Entrepreneur or Startup Employee](https://www.scribd.com/doc/55945011/An-Introduction-to-Stock-Options-for-the-Tech-Entrepreneur-or-Startup-Employee#scribd)
-- Anonymous,
-  [What I Wish I’d Known About Equity Before Joining A Unicorn](https://gist.github.com/yossorion/4965df74fd6da6cdc280ec57e83a202d)
-- Investopedia,
-  [Employee Stock Options: Definitions and Key Concepts](http://www.investopedia.com/university/employee-stock-options-eso/eso1.asp)
-- Dan Shapiro, [Vesting is a hack](http://www.danshapiro.com/blog/2012/04/vesting-is-a-hack/)
-- Guy Kawasaki, [Nine Questions to Ask a Startup](http://guykawasaki.com/nine_questions_/)
-- Alex MacCaw,
-  [An Engineer’s Guide to Stock Options](http://blog.alexmaccaw.com/an-engineers-guide-to-stock-options)
-- Robby Grossman,
-  [Negotiating Your Startup Job Offer](http://rob.by/2013/negotiating-your-startup-job-offer/)
-- Julia Evans,
-  [Things you should know about stock options before negotiating an offer](http://jvns.ca/blog/2015/12/30/do-the-math-on-your-stock-options/)
-- Joe Wallin,
-  [RSUs vs. Restricted Stock vs. Stock Options](http://joewallin.com/2014/09/13/rsus-vs-restricted-stock-vs-stock-options/)
-- Joshua Levy and Joe Wallin,
-  [The Problem With Immediately Exercisable ISOs](http://thestartuplawblog.com/the-problem-with-immediately-exercisable-isos/)
-- Barry Kramer,
-  [🔑The Tax Law that is (Unintentionally) Hammering Silicon Valley Employees](https://medium.com/@barryjk/the-tax-law-that-is-unintentionally-hammering-silicon-valley-employees-894a7b54ba8a)
-- Startup Law Blog,
-  [Incentive Stock Options vs. Nonqualified Stock Options](http://www.startuplawblog.com/2013/05/15/incentive-stock-options-vs-nonqualified-stock-options/)
-- Startup Law Blog,
-  [Top 6 Reasons To Grant NQOs Over ISOs](http://www.startuplawblog.com/2010/08/11/top-reasons-nqos-over-isos/)
-- Investopedia,
-  [How Restricted Stock And RSUs Are Taxed](http://www.investopedia.com/articles/tax/09/restricted-stock-tax.asp?performancelayout=true)
-- Investopedia,
-  [Introduction To Incentive Stock Options](http://www.investopedia.com/articles/stocks/12/introduction-incentive-stock-options.asp)
-- Forbes,
-  [Ten Tax Tips For Stock Options](http://www.forbes.com/2010/03/10/10-tax-tips-stock-options-personal-finance-robert-wood.html)
-- Wealthfront,
-  [When Should You Exercise Your Stock Options?](https://blog.wealthfront.com/when-to-exercise-stock-options/)
-- Wealthfront,
-  [The 14 Crucial Questions about Stock Options](https://blog.wealthfront.com/stock-options-14-crucial-questions/)
-- Leo Polovets, [Valuing Employee Options](http://codingvc.com/valuing-employee-options/)
-- Leo Polovets,
-  [Analyzing AngelList Job Postings, Part 2: Salary and Equity Benchmarks](http://codingvc.com/analyzing-angellist-job-postings-part-2-salary-and-equity-benchmarks)
-- Inc,
-  [5 Questions You Should Ask Before Accepting a Startup Job Offer](http://www.inc.com/atish-davda/5-questions-you-should-ask-before-taking-a-start-up-job-offer.html)
-- GigaOm,
-  [5 Mistakes You Can’t Afford to Make with Stock Options](https://gigaom.com/2011/06/05/5-mistakes-you-cant-afford-to-make-with-stock-options/)
-- Wealthfront,
-  [How Do Stock Options and RSUs Differ?](https://blog.wealthfront.com/stock-options-versus-rsu/)
-- Mary Russell,
-  [Startup Equity Standards: A Guide for Employees](http://www.slideshare.net/StockOptionCnsl/startup-standards-stock-option-counsel)
-- Mary Russell,
-  [Can the Company Take Back My Vested Shares?](http://stockoptioncounsel.com/blog/standards-ownership-canthecomanytakebackmyvestedshares)
-- Fairmark,
-  [AMT and Long-Term Capital Gain](http://fairmark.com/general-taxation/alternative-minimum-tax/amt-long-term-capital-gain/)
-- NCEO,
-  [Stock Options and the Alternative Minimum Tax (AMT)](https://www.nceo.org/articles/stock-options-alternative-minimum-tax-amt)
-- Accelerated Vesting,
-  [What Is An 83(b) Election and When Do I Make It?](http://acceleratedvesting.com/what-is-an-83b-election-and-when-do-i-make-it-part-1-with-graphic/)
-- Fenwick,
-  [Section 409A Valuations and Stock Option Grants for Start-up Technology and Life Science Companies](http://www.fenwick.com/FenwickDocuments/409_Valuations_Stock_Options.pdf)
-- Venture Hacks, [How to make a cap table](http://venturehacks.com/articles/cap-table)
-- VentureBeat,
-  [Beware the trappings of liquidation preference](http://venturebeat.com/2010/08/16/beware-the-trappings-of-liquidation-preference/)
-- Orrick, 📥[Startup Forms: Equity Compensation](https://www.orrick.com/Total-Access/Tool-Kit/Start-Up-Forms/Equity-Compensation)
-- Matthew Bartus,
-  [Option Grants: Fully Diluted or Issued and Outstanding](https://www.cooleygo.com/option-grants-fully-diluted-issued-outstanding/)
-- Babak Nivi, [The Option Pool Shuffle](http://venturehacks.com/articles/option-pool-shuffle)
-  (and [table of equity](http://venturehacks.com/articles/option-pool-shuffle#market) ranges)
-- 🔨 [TLDR Stock Options](https://tldroptions.io/) and
-  [OwnYourVenture](http://ownyourventure.com/) are simulators illustrating equity calculations
-  and dilution
+    - **Introductory resources**
+      - Mark P. Cussen, Investopedia,
+        [*Introduction To Incentive Stock Options*](http://www.investopedia.com/articles/stocks/12/introduction-incentive-stock-options.asp),
+        updated 2017.
+      - Alex MacCaw,
+        [*An Engineer’s Guide to Stock Options*](http://blog.alexmaccaw.com/an-engineers-guide-to-stock-options),
+        2013\.
+      - Andy Rachleff, Wealthfront,[*The 14 Crucial Questions about Stock Options*](https://blog.wealthfront.com/stock-options-14-crucial-questions/),
+        2014\.
+      - Mary Russell, Stock Option Counsel,
+        [*Startup Equity Standards: A Guide for Employees*](http://www.slideshare.net/StockOptionCnsl/startup-standards-stock-option-counsel),
+        2014\.
+      - David Weekly,
+        [ 💰*An Introduction to Stock & Options for the Tech Entrepreneur or Startup Employee*](https://www.scribd.com/doc/55945011/An-Introduction-to-Stock-Options-for-the-Tech-Entrepreneur-or-Startup-Employee#scribd),
+        2012\.
+      - Investopedia,
+        [*Employee Stock Options: Definitions and Key Concepts*](http://www.investopedia.com/university/employee-stock-options-eso/eso1.asp)
+    - **Considerations for candidates and employees**
+      - Anonymous,
+        [*What I Wish I’d Known About Equity Before Joining A Unicorn*](https://gist.github.com/yossorion/4965df74fd6da6cdc280ec57e83a202d),
+        2017\.
+      - Atish Davda, Inc,
+        [*5 Questions You Should Ask Before Accepting a Startup Job Offer*](http://www.inc.com/atish-davda/5-questions-you-should-ask-before-taking-a-start-up-job-offer.html),
+        2014\.
+      - Julia Evans,
+        [*Things you should know about stock options before negotiating an offer*](http://jvns.ca/blog/2015/12/30/do-the-math-on-your-stock-options/),
+        2015\.
+      - Robby Grossman,
+        [*Negotiating Your Startup Job Offer*](http://rob.by/2013/negotiating-your-startup-job-offer/),
+        2013\.
+      - Guy Kawasaki, [*Nine Questions to Ask a Startup*](http://guykawasaki.com/nine_questions_/),
+        2006\.
+      - Leo Polovets,
+        [*Analyzing AngelList Job Postings, Part 2: Salary and Equity Benchmarks*](http://codingvc.com/analyzing-angellist-job-postings-part-2-salary-and-equity-benchmarks),
+        2014\.
+      - Leo Polovets, [*Valuing Employee Options*](http://codingvc.com/valuing-employee-options/),
+        2015\.
+      - Andy Rachleff, Wealthfront,
+        [*When Should You Exercise Your Stock Options?*](https://blog.wealthfront.com/when-to-exercise-stock-options/),
+        2015\.
+      - David Weekly, GigaOm,
+        [*5 Mistakes You Can’t Afford to Make with Stock Options*](https://gigaom.com/2011/06/05/5-mistakes-you-cant-afford-to-make-with-stock-options/),
+        2011\.
+    - **Types of equity compensation**
+      - Andy Rachleff, Wealthfront,[*How Do Stock Options and RSUs Differ?*](https://blog.wealthfront.com/stock-options-versus-rsu/),
+        2014\.
+      - Joe Wallin, The Startup Law Blog,
+        [*Incentive Stock Options vs. Nonqualified Stock Options*](http://www.startuplawblog.com/2013/05/15/incentive-stock-options-vs-nonqualified-stock-options/),
+        2013\.
+      - Joe Wallin,
+        [*RSUs vs. Restricted Stock vs. Stock Options*](http://joewallin.com/2014/09/13/rsus-vs-restricted-stock-vs-stock-options/),
+        2014\.
+      - Joe Wallin, The Startup Law Blog,[*Top 6 Reasons To Grant NQOs Over ISOs*](http://www.startuplawblog.com/2010/08/11/top-reasons-nqos-over-isos/),
+        2010\.
+    - **Taxes**
+      - Mark P. Cussen, Investopedia,[*How Restricted Stock And RSUs Are Taxed*](http://www.investopedia.com/articles/tax/09/restricted-stock-tax.asp?performancelayout=true).
+      - Barry Kramer,
+        [🔑*The Tax Law that is (Unintentionally) Hammering Silicon Valley Employees*](https://medium.com/@barryjk/the-tax-law-that-is-unintentionally-hammering-silicon-valley-employees-894a7b54ba8a),
+        2015\.
+      - Kaye A. Thomas, Fairmark,
+        [*AMT and Long-Term Capital Gain*](http://fairmark.com/general-taxation/alternative-minimum-tax/amt-long-term-capital-gain/),
+        2014\.
+      - Robert W. Wood, Forbes,
+        [*Ten Tax Tips For Stock Options*](http://www.forbes.com/2010/03/10/10-tax-tips-stock-options-personal-finance-robert-wood.html),
+        2010\.
+      - NCEO,
+        [*Stock Options and the Alternative Minimum Tax (AMT)*](https://www.nceo.org/articles/stock-options-alternative-minimum-tax-amt)
+    - **Specialized topics**
+      - Steven Ayre, Accelerated Vesting,
+        [*What Is An 83(b) Election and When Do I Make It?*](http://acceleratedvesting.com/what-is-an-83b-election-and-when-do-i-make-it-part-1-with-graphic/),
+        2013\.
+      - Matthew Bartus, Cooley GO,
+        [*Option Grants: Fully Diluted or Issued and Outstanding*](https://www.cooleygo.com/option-grants-fully-diluted-issued-outstanding/)
+      - Joshua Levy and Joe Wallin, The Startup Law Blog,
+        [\*The Problem With Immediately Exercisable ISOs](http://thestartuplawblog.com/the-problem-with-immediately-exercisable-isos/),
+        2015\.
+      - Tahir J. Naim, Fenwick,
+        [*Section 409A Valuations and Stock Option Grants for Start-up Technology and Life Science Companies*](http://www.fenwick.com/FenwickDocuments/409_Valuations_Stock_Options.pdf).
+      - Babak Nivi, Venture Hacks,
+        [*How to make a cap table*](http://venturehacks.com/articles/cap-table), 2007.
+      - Babak Nivi, [*The Option Pool Shuffle*](http://venturehacks.com/articles/option-pool-shuffle)
+        (and [table of equity](http://venturehacks.com/articles/option-pool-shuffle#market) ranges),
+        2017\.
+      - Mary Russell, Stock Option Counsel,
+        [*Can the Company Take Back My Vested Shares?*](http://stockoptioncounsel.com/blog/standards-ownership-canthecomanytakebackmyvestedshares),
+        2017\.
+      - Dan Shapiro, [*Vesting is a hack*](http://www.danshapiro.com/blog/2012/04/vesting-is-a-hack/),
+        2012\.
+      - Scott Edward Walker, VentureBeat,
+        [*Beware the trappings of liquidation preference*](http://venturebeat.com/2010/08/16/beware-the-trappings-of-liquidation-preference/),
+        2010\.
+    - **Forms and tools**
+      - [🔨TLDR Stock Options](https://tldroptions.io/) and [OwnYourVenture](http://ownyourventure.com/)
+        are simulators illustrating equity calculations and dilution
+      - Orrick,
+        [📥Startup Forms: Equity Compensation](https://www.orrick.com/Total-Access/Tool-Kit/Start-Up-Forms/Equity-Compensation)
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -2703,17 +2703,17 @@ It’s not exhaustive, as titles and details vary.
       - Investopedia,
         [*Employee Stock Options: Definitions and Key Concepts*](http://www.investopedia.com/university/employee-stock-options-eso/eso1.asp).
     - **Considerations for founders**
-     -  Matthew Bartus, Cooley GO,
+      -  Matthew Bartus, Cooley GO,
       [*Option Grants: Fully Diluted or Issued and Outstanding*](https://www.cooleygo.com/option-grants-fully-diluted-issued-outstanding/).
-     - Jay Bhatti, Business Insider,
+      - Jay Bhatti, Business Insider,
       [*How Startups Should Deal With Cliff Vesting For Employees*](http://www.businessinsider.com/everything-you-need-to-know-about-cliff-vesting-2011-5),
       2011\.
-     - Babak Nivi, [*The Option Pool Shuffle*](http://venturehacks.com/articles/option-pool-shuffle)
+      - Babak Nivi, [*The Option Pool Shuffle*](http://venturehacks.com/articles/option-pool-shuffle)
       (and [table of equity](http://venturehacks.com/articles/option-pool-shuffle#market) ranges), 2017\.
-     - Leo Polovets,
+      - Leo Polovets,
       [*Analyzing AngelList Job Postings, Part 2: Salary and Equity Benchmarks*](http://codingvc.com/analyzing-angellist-job-postings-part-2-salary-and-equity-benchmarks), 2014\.
-     - Joe Wallin, The Startup Law Blog,[*Top 6 Reasons To Grant NQOs Over ISOs*](http://www.startuplawblog.com/2010/08/11/top-reasons-nqos-over-isos/), 2010\.
-      - Clerky, [*Legal Concepts for Founders*](https://handbook.clerky.com/).
+      - Joe Wallin, The Startup Law Blog,[*Top 6 Reasons To Grant NQOs Over ISOs*](http://www.startuplawblog.com/2010/08/11/top-reasons-nqos-over-isos/), 2010\.
+      - Clerky, [*Legal Concepts for Founders*](https://handbook.clerky.com/).     
     - **Considerations for candidates and employees**
       - Anonymous,
         [*What I Wish I’d Known About Equity Before Joining A Unicorn*](https://gist.github.com/yossorion/4965df74fd6da6cdc280ec57e83a202d),
@@ -2743,14 +2743,14 @@ It’s not exhaustive, as titles and details vary.
         [*5 Mistakes You Can’t Afford to Make with Stock Options*](https://gigaom.com/2011/06/05/5-mistakes-you-cant-afford-to-make-with-stock-options/),
         2011\.
     - **Types of equity compensation**
-     - Jeron Paul, Capshare,
+      - Jeron Paul, Capshare,
       [*RSUs vs. Options: Why RSUs (Restricted Stock Units) Could be Better Than Stock Options At Your Private Company*](https://www.capshare.com/blog/rsus-vs-options/),
       2016\.
-     - Andy Rachleff, Wealthfront,
+      - Andy Rachleff, Wealthfront,
       [*How Do Stock Options and RSUs Differ?*](https://blog.wealthfront.com/stock-options-versus-rsu/), 2014\.
-     - Joe Wallin, The Startup Law Blog,
+      - Joe Wallin, The Startup Law Blog,
       [*Incentive Stock Options vs. Nonqualified Stock Options*](http://www.startuplawblog.com/2013/05/15/incentive-stock-options-vs-nonqualified-stock-options/), 2013\.
-     - Joe Wallin,
+      - Joe Wallin,
       [*RSUs vs. Restricted Stock vs. Stock Options*](http://joewallin.com/2014/09/13/rsus-vs-restricted-stock-vs-stock-options/), 2014\.
     - **Taxes**
       - Mark P. Cussen, Investopedia,[*How Restricted Stock And RSUs Are Taxed*](http://www.investopedia.com/articles/tax/09/restricted-stock-tax.asp?performancelayout=true).

--- a/README.md
+++ b/README.md
@@ -2737,7 +2737,7 @@ It’s not exhaustive, as titles and details vary.
         2013.
       - Guy Kawasaki, [*Nine Questions to Ask a Startup*](http://guykawasaki.com/nine_questions_/),
         2006.
-      - Maria Konnikova, the New Yorker
+      - Maria Konnikova, The New Yorker,
         [*Lean Out: The Dangers for Women who Negotiate*](https://www.newyorker.com/science/maria-konnikova/lean-out-the-dangers-for-women-who-negotiate)
       - Eileen Patten, Pew Research Center,
         [*Racial, gender wage gaps persist in U.S. despite some progress*](http://www.pewresearch.org/fact-tank/2016/07/01/racial-gender-wage-gaps-persist-in-u-s-despite-some-progress/),

--- a/README.md
+++ b/README.md
@@ -2687,107 +2687,118 @@ It’s not exhaustive, as titles and details vary.
     - **General resources**
       - Mark P. Cussen, Investopedia,
         [*Introduction To Incentive Stock Options*](http://www.investopedia.com/articles/stocks/12/introduction-incentive-stock-options.asp),
-        updated 2017\.
+        updated 2017.
       - Alex MacCaw,
         [*An Engineer’s Guide to Stock Options*](http://blog.alexmaccaw.com/an-engineers-guide-to-stock-options),
-        2013\.
+        2013.
       - Andy Rachleff, Wealthfront,
         [*The 14 Crucial Questions about Stock Options*](https://blog.wealthfront.com/stock-options-14-crucial-questions),
-        2014\.
+        2014.
       - Mary Russell, Stock Option Counsel,
         [*Startup Equity Standards: A Guide for Employees*](http://www.slideshare.net/StockOptionCnsl/startup-standards-stock-option-counsel),
-        2014\.
+        2014.
       - David Weekly,
         [ 💰*An Introduction to Stock & Options for the Tech Entrepreneur or Startup Employee*](https://www.scribd.com/doc/55945011/An-Introduction-to-Stock-Options-for-the-Tech-Entrepreneur-or-Startup-Employee#scribd),
-        2012\.
+        2012.
       - Investopedia,
         [*Employee Stock Options: Definitions and Key Concepts*](http://www.investopedia.com/university/employee-stock-options-eso/eso1.asp).
     - **Considerations for founders**
-      -  Matthew Bartus, Cooley GO,
+      - Matthew Bartus, Cooley GO,
         [*Option Grants: Fully Diluted or Issued and Outstanding*](https://www.cooleygo.com/option-grants-fully-diluted-issued-outstanding/).
       - Jay Bhatti, Business Insider,
         [*How Startups Should Deal With Cliff Vesting For Employees*](http://www.businessinsider.com/everything-you-need-to-know-about-cliff-vesting-2011-5),
-      2011\.
+        2011.
       - Tahir J. Naim, Fenwick,
         [*Section 409A Valuations and Stock Option Grants for Start-up Technology and Life Science Companies*](http://www.fenwick.com/FenwickDocuments/409_Valuations_Stock_Options.pdf).
-      - Babak Nivi, Venture Hacks [*The Option Pool Shuffle*](http://venturehacks.com/articles/option-pool-shuffle)
-      (and [table of equity](http://venturehacks.com/articles/option-pool-shuffle#market) ranges), 2017\.
+      - Babak Nivi, Venture Hacks
+        [*The Option Pool Shuffle*](http://venturehacks.com/articles/option-pool-shuffle) (and
+        [table of equity](http://venturehacks.com/articles/option-pool-shuffle#market) ranges), 2017.
       - Leo Polovets,
-      [*Analyzing AngelList Job Postings, Part 2: Salary and Equity Benchmarks*](http://codingvc.com/analyzing-angellist-job-postings-part-2-salary-and-equity-benchmarks), 2014\.
+        [*Analyzing AngelList Job Postings, Part 2: Salary and Equity Benchmarks*](http://codingvc.com/analyzing-angellist-job-postings-part-2-salary-and-equity-benchmarks),
+        2014.
       - Scott Edward Walker, VentureBeat,
-      [*Beware the trappings of liquidation preference*](http://venturebeat.com/2010/08/16/beware-the-trappings-of-liquidation-preference/), 2010\.
-      - Joe Wallin, The Startup Law Blog,[*Top 6 Reasons To Grant NQOs Over ISOs*](http://www.startuplawblog.com/2010/08/11/top-reasons-nqos-over-isos/), 2010\.
-      - Clerky, [*Legal Concepts for Founders*](https://handbook.clerky.com/).    
+        [*Beware the trappings of liquidation preference*](http://venturebeat.com/2010/08/16/beware-the-trappings-of-liquidation-preference/),
+        2010.
+      - Joe Wallin, The Startup Law Blog,[*Top 6 Reasons To Grant NQOs Over ISOs*](http://www.startuplawblog.com/2010/08/11/top-reasons-nqos-over-isos/),
+        2010.
+      - Clerky, [*Legal Concepts for Founders*](https://handbook.clerky.com/).
     - **Considerations for candidates and employees**
       - Anonymous,
         [*What I Wish I’d Known About Equity Before Joining A Unicorn*](https://gist.github.com/yossorion/4965df74fd6da6cdc280ec57e83a202d),
-        2017\.
+        2017.
       - Atish Davda, Inc,
         [*5 Questions You Should Ask Before Accepting a Startup Job Offer*](http://www.inc.com/atish-davda/5-questions-you-should-ask-before-taking-a-start-up-job-offer.html),
-        2014\.
+        2014.
       - Julia Evans,
         [*Things you should know about stock options before negotiating an offer*](http://jvns.ca/blog/2015/12/30/do-the-math-on-your-stock-options/),
-        2015\.
+        2015.
       - Robby Grossman,
         [*Negotiating Your Startup Job Offer*](http://rob.by/2013/negotiating-your-startup-job-offer/),
-        2013\.
+        2013.
       - Guy Kawasaki, [*Nine Questions to Ask a Startup*](http://guykawasaki.com/nine_questions_/),
-        2006\.
+        2006.
       - Maria Konnikova, the New Yorker
         [*Lean Out: The Dangers for Women who Negotiate*](https://www.newyorker.com/science/maria-konnikova/lean-out-the-dangers-for-women-who-negotiate)
       - Eileen Patten, Pew Research Center,
         [*Racial, gender wage gaps persist in U.S. despite some progress*](http://www.pewresearch.org/fact-tank/2016/07/01/racial-gender-wage-gaps-persist-in-u-s-despite-some-progress/),
-        2016\.
-      - Leo Polovets, [*Valuing Employee Options*](http://codingvc.com/valuing-employee-options/),
-        2015\.
+        2016.
+      - Leo Polovets, [*Valuing Employee Options*](http://codingvc.com/valuing-employee-options/), 2015.
       - Andy Rachleff, Wealthfront,
         [*When Should You Exercise Your Stock Options?*](https://blog.wealthfront.com/when-to-exercise-stock-options/),
-        2015\.
+        2015.
       - David Weekly, GigaOm,
         [*5 Mistakes You Can’t Afford to Make with Stock Options*](https://gigaom.com/2011/06/05/5-mistakes-you-cant-afford-to-make-with-stock-options/),
-        2011\.
+        2011.
     - **Types of equity compensation**
       - Jeron Paul, Capshare,
-      [*RSUs vs. Options: Why RSUs (Restricted Stock Units) Could be Better Than Stock Options At Your Private Company*](https://www.capshare.com/blog/rsus-vs-options/),
-      2016\.
+        [*RSUs vs. Options: Why RSUs (Restricted Stock Units) Could be Better Than Stock Options At Your Private Company*](https://www.capshare.com/blog/rsus-vs-options/),
+        2016.
       - Andy Rachleff, Wealthfront,
-      [*How Do Stock Options and RSUs Differ?*](https://blog.wealthfront.com/stock-options-versus-rsu/), 2014\.
+        [*How Do Stock Options and RSUs Differ?*](https://blog.wealthfront.com/stock-options-versus-rsu/),
+        2014.
       - Joe Wallin, The Startup Law Blog,
-      [*Incentive Stock Options vs. Nonqualified Stock Options*](http://www.startuplawblog.com/2013/05/15/incentive-stock-options-vs-nonqualified-stock-options/), 2013\.
+        [*Incentive Stock Options vs. Nonqualified Stock Options*](http://www.startuplawblog.com/2013/05/15/incentive-stock-options-vs-nonqualified-stock-options/),
+        2013.
       - Joe Wallin,
-      [*RSUs vs. Restricted Stock vs. Stock Options*](http://joewallin.com/2014/09/13/rsus-vs-restricted-stock-vs-stock-options/), 2014\.
+        [*RSUs vs. Restricted Stock vs. Stock Options*](http://joewallin.com/2014/09/13/rsus-vs-restricted-stock-vs-stock-options/),
+        2014.
     - **Taxes**
       - Steven Ayre, Accelerated Vesting,
-      [*What Is An 83(b) Election and When Do I Make It?*](http://acceleratedvesting.com/what-is-an-83b-election-and-when-do-i-make-it-part-1-with-graphic/),
-      2013\.
-      - Mark P. Cussen, Investopedia, [*How Restricted Stock And RSUs Are Taxed*](http://www.investopedia.com/articles/tax/09/restricted-stock-tax.asp?performancelayout=true).
+        [*What Is An 83(b) Election and When Do I Make It?*](http://acceleratedvesting.com/what-is-an-83b-election-and-when-do-i-make-it-part-1-with-graphic/),
+        2013.
+      - Mark P. Cussen, Investopedia,
+        [*How Restricted Stock And RSUs Are Taxed*](http://www.investopedia.com/articles/tax/09/restricted-stock-tax.asp?performancelayout=true).
       - Barry Kramer,
         [🔑*The Tax Law that is (Unintentionally) Hammering Silicon Valley Employees*](https://medium.com/@barryjk/the-tax-law-that-is-unintentionally-hammering-silicon-valley-employees-894a7b54ba8a),
-        2015\.
+        2015.
       - Joshua Levy and Joe Wallin, The Startup Law Blog,
-          [*The Problem With Immediately Exercisable ISOs*](http://thestartuplawblog.com/the-problem-with-immediately-exercisable-isos/),
-          2015\.
+        [*The Problem With Immediately Exercisable ISOs*](http://thestartuplawblog.com/the-problem-with-immediately-exercisable-isos/),
+        2015.
       - Kaye A. Thomas, Fairmark,
         [*AMT and Long-Term Capital Gain*](http://fairmark.com/general-taxation/alternative-minimum-tax/amt-long-term-capital-gain/),
-        2014\.
+        2014.
       - Robert W. Wood, Forbes,
         [*Ten Tax Tips For Stock Options*](http://www.forbes.com/2010/03/10/10-tax-tips-stock-options-personal-finance-robert-wood.html),
-        2010\.
+        2010.
       - NCEO,
         [*Stock Options and the Alternative Minimum Tax (AMT)*](https://www.nceo.org/articles/stock-options-alternative-minimum-tax-amt)
     - **Vesting and expiration of stock options**
       - Babak Nivi, Venture Hacks,
-      [*How to make a cap table*](http://venturehacks.com/articles/cap-table), 2007\.
+        [*How to make a cap table*](http://venturehacks.com/articles/cap-table), 2007.
       - Mary Russell, Stock Option Counsel,
-      [*Can the Company Take Back My Vested Shares?*](http://stockoptioncounsel.com/blog/standards-ownership-canthecomanytakebackmyvestedshares), 2017\.
-      - Mary Russell, Stock Option Counsel, [*Early Expiration of Startup Stock Options - Part 1 - A $1 Million Problem*](http://stockoptioncounsel.com/blog/nc7go8ivzxb1el5rhv6nltrjan0n2t/2017/3/6), 2017\.
+        [*Can the Company Take Back My Vested Shares?*](http://stockoptioncounsel.com/blog/standards-ownership-canthecomanytakebackmyvestedshares),
+        2017.
       - Mary Russell, Stock Option Counsel,
-     [*Early Expiration of Startup Stock Options - Part 2 -The Full 10-Year Term Solution*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-2-the-full-10-year-term-solution/2017/3/28),
-     2017\.
+        [*Early Expiration of Startup Stock Options - Part 1 - A $1 Million Problem*](http://stockoptioncounsel.com/blog/nc7go8ivzxb1el5rhv6nltrjan0n2t/2017/3/6),
+        2017.
       - Mary Russell, Stock Option Counsel,
-     [*Early Expiration of Startup Stock Options - Part 3 - Examples of Good Equity Design by Company Stage*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-3-examples-of-good-startup-equity-design-by-company-stage/2017/8/11),
-     2017\.
-      - Dan Shapiro, [*Vesting is a hack*](http://www.danshapiro.com/blog/2012/04/vesting-is-a-hack/), 2012\.
+        [*Early Expiration of Startup Stock Options - Part 2 -The Full 10-Year Term Solution*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-2-the-full-10-year-term-solution/2017/3/28),
+        2017.
+      - Mary Russell, Stock Option Counsel,
+        [*Early Expiration of Startup Stock Options - Part 3 - Examples of Good Equity Design by Company Stage*](http://stockoptioncounsel.com/blog/early-expiration-of-startup-stock-options-part-3-examples-of-good-startup-equity-design-by-company-stage/2017/8/11),
+        2017.
+      - Dan Shapiro, [*Vesting is a hack*](http://www.danshapiro.com/blog/2012/04/vesting-is-a-hack/),
+        2012.
     - **Forms and tools**
       - [🔨TLDR Stock Options](https://tldroptions.io/) and [OwnYourVenture](http://ownyourventure.com/)
         are simulators illustrating equity calculations and dilution


### PR DESCRIPTION
UPDATED NOTE: In atom the alignment of items looks right in both the editor and markdown preview. In GitHub just looking at the readme of the branch, some sections of Further Reading are misaligned.

Considerations:
-Some pieces don't have all three author/date/org (so format is "First Last, Org, *Title*, year.")
-Authors not associated with an org or publishing under their own name have no org listed
-Styling of author/org?
-Add "definitive" emojis?
-Labels for FR subsections are spare. We could add more context.
-Some links could be classified a variety of ways. Feel free to make suggestions if you don't like the bucket I put something in.
-Rather than order sections alphabetically could group by importance or topic.
-Link authors?
