### PR TITLE
unbolded a few incidental terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,8 +505,8 @@ There may be few or no transactions, or they may not be publicly known.
 🄳 A corporation has a **board of directors**, a
 [small group of people](https://en.wikipedia.org/wiki/Board_of_directors) whose legal
 obligation is to oversee the company and ensure it serves the best interests of the
-shareholders. The board typically consists of both *inside directors*, such as the CEO,
-other founders, or executives employed by the company, and *outside directors*, who are
+shareholders. The board typically consists of both **inside directors**, such as the CEO,
+other founders, or executives employed by the company, and **outside directors**, who are
 not involved in the day-to-day workings of the company.
 Many decisions around granting equity to employees are approved by the board of directors.
 
@@ -1512,7 +1512,7 @@ and consist of Social Security and
 that are withheld from your paycheck.
 The Social Security wage withholding rate is **6.2%** up to the FICA wage base.
 The Medicare component is **1.45%**, and it does not phase out above the FICA wage base.
-You’ll also hear these called [*payroll taxes*](https://en.wikipedia.org/wiki/Payroll_tax) as
+You’ll also hear these called [**payroll taxes**](https://en.wikipedia.org/wiki/Payroll_tax) as
 they often show up on your pay stub.
 
 - 🚧 Review and add more links on SS and Medicare taxes.
@@ -2095,7 +2095,7 @@ private.
   offering to sell their shares to the company first.
 - Unlike a transaction on a public exchange, the buyer and seller of private company stock
   are not in total control of the sale.
-  There are a few reasons why companies may not support secondary sales:
+  There are a few reasons **why companies may not support secondary sales**:
   - Historically, startups have seen little purpose in letting current employees sell their
     stock, since they prefer employees hold their stock and work to make it more valuable by
     improving the value of the company as a whole.
@@ -2584,7 +2584,7 @@ A few notes on the negotiation process itself:
 - ❗ Get all agreements in writing, if they are not in your offer letter.
 - Do not accept an offer verbally or in writing unless you’re ready to stand by your word.
   In practice, people do occasionally accept an offer and then go back on it, or
-  [renege](https://purduecco.wordpress.com/2016/03/28/the-risks-of-reneging-on-a-job-offer/).
+  [*renege*](https://purduecco.wordpress.com/2016/03/28/the-risks-of-reneging-on-a-job-offer/).
   This can put the company in a difficult position (they may have declined another key
   candidate based on your acceptance), and may hurt your reputation in unexpected ways
   later.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Topics **not yet covered**:
 
 ### How this Guide is organized
 
-This Guide contains **a lot** of material.
+This Guide contains a lot of material.
 And it’s dense.
 Some readers may wish to read front to back, but you can also **search or navigate directly**
 to parts that are of interest to you, **referring back** to foundational topics as needed.
@@ -505,8 +505,8 @@ There may be few or no transactions, or they may not be publicly known.
 🄳 A corporation has a **board of directors**, a
 [small group of people](https://en.wikipedia.org/wiki/Board_of_directors) whose legal
 obligation is to oversee the company and ensure it serves the best interests of the
-shareholders. The board typically consists of both **inside directors**, such as the CEO,
-other founders, or executives employed by the company, and **outside directors**, who are
+shareholders. The board typically consists of both *inside directors*, such as the CEO,
+other founders, or executives employed by the company, and *outside directors*, who are
 not involved in the day-to-day workings of the company.
 Many decisions around granting equity to employees are approved by the board of directors.
 
@@ -1148,7 +1148,7 @@ of employee stock options.
 
 🚧 Any real-world examples or statistics of how low strike price has led to big payoffs?
 
-🚧 Mention and relate this to the term **employee stock options (or ESOs)**? Dispel any
+🚧 Mention and relate this to the term *employee stock options (or ESOs)*? Dispel any
 confusion between ESOs and ESPPs?
 
 ### Vesting and cliffs
@@ -1481,7 +1481,7 @@ to tax rates for the **2018** tax year.
 Long-term capital gains taxes
 [did not change significantly](https://www.marketwatch.com/story/your-simple-guide-to-the-new-capital-gains-tax-rates-2018-04-16).
 
-🚧 Can we clarify the term **investment income** too?
+🚧 Can we clarify the term *investment income* too?
 
 ### Federal taxes
 
@@ -1512,7 +1512,7 @@ and consist of Social Security and
 that are withheld from your paycheck.
 The Social Security wage withholding rate is **6.2%** up to the FICA wage base.
 The Medicare component is **1.45%**, and it does not phase out above the FICA wage base.
-You’ll also hear these called **[payroll taxes](https://en.wikipedia.org/wiki/Payroll_tax)** as
+You’ll also hear these called [*payroll taxes*](https://en.wikipedia.org/wiki/Payroll_tax) as
 they often show up on your pay stub.
 
 - 🚧 Review and add more links on SS and Medicare taxes.
@@ -1714,7 +1714,7 @@ But you should also know a bit about tax rates in your state.
 
 State long-term capital gains rates
 [range widely](http://www.fool.com/personal-finance/taxes/2014/10/04/the-states-with-the-highest-capital-gains-tax-rate.aspx).
-**California** has the highest, at **13.3%**; several states have none.
+California has the highest, at **13.3%**; several states have none.
 
 🔹 For this reason, some people even
 [consider moving](https://www.forbes.com/sites/robertwood/2016/05/17/can-you-avoid-california-taxes-by-moving/#316bd9471694)
@@ -2095,7 +2095,7 @@ private.
   offering to sell their shares to the company first.
 - Unlike a transaction on a public exchange, the buyer and seller of private company stock
   are not in total control of the sale.
-  There are a few reasons **why companies may not support secondary sales**:
+  There are a few reasons why companies may not support secondary sales:
   - Historically, startups have seen little purpose in letting current employees sell their
     stock, since they prefer employees hold their stock and work to make it more valuable by
     improving the value of the company as a whole.
@@ -2141,12 +2141,11 @@ private.
 Some of these items have already been discussed, but they’re important enough to consider
 all together when trying to assign value to your equity:
 
-- ❗ **Details matter**: When it comes to equity compensation, details matter!
+- ❗ When it comes to equity compensation, details matter!
   You need to understand the type of stock grant or stock option in detail, as well as what
   it means for your taxes, to know what your equity is worth.
-- ❗ **Seek professional advice and understand it**: Because details are so important,
-  [professional advice](#seeking-professional-advice) from a tax advisor or lawyer familiar with
-  equity compensation (or both) is often a good idea.
+- ❗ Because details are so important, [professional advice](#seeking-professional-advice) from
+  a tax advisor or lawyer familiar with equity compensation (or both) is often a good idea.
   Avoid doing everything yourself, but also avoid blindly trusting advisors without having
   them explain the details to you in a way you understand.
 - ❗ In some cases, high taxes may prevent you from exercising your options, and if you can’t
@@ -2446,7 +2445,7 @@ Companies often pay for this data from
 [vendors](https://www.advanced-hr.com/products-overview), but it’s usually not available to
 candidates.
 
-For **startups**, a variety of data is easier to come by.
+For startups, a variety of data is easier to come by.
 We give some overview here of early-stage Silicon Valley tech startups;
 many of these numbers are not representative of companies of different kinds across the
 country:
@@ -2583,8 +2582,7 @@ A few notes on the negotiation process itself:
     companies is considered bad form by some;
     it’s thoughtful to be judicious and timely to the extent that it’s possible.
 - ❗ Get all agreements in writing, if they are not in your offer letter.
-- **Reneging on offers**: Do not accept an offer verbally or in writing unless you’re ready to
-  stand by your word.
+- Do not accept an offer verbally or in writing unless you’re ready to stand by your word.
   In practice, people do occasionally accept an offer and then go back on it, or
   [renege](https://purduecco.wordpress.com/2016/03/28/the-risks-of-reneging-on-a-job-offer/).
   This can put the company in a difficult position (they may have declined another key


### PR DESCRIPTION
Also removed a couple of bolded phrases that were inconsistent with the structure of the section.

Reviewers please check that this is consistent with what we want so we can clarify the rule. A bit of this is instinctual (does that phrase really need to be called out in bold or will italics suffice?), and we may disagree. Bolded phrases followed by colons are not super consistent in the Guide so I tried to make them consistent at least within sections. (E.g. if a bulleted list has five items and two have introductory bolded phrases followed by a colon, you can remove that phrase and the colon and just jump into the point, IMO.) I also think it's worth adding a rule not to bold anything within a 🚧, as I think bold gives a lot of weight to something not yet present; I changed bolded terms within 🚧 to ital, even if in the future they'll be definitions. LMK! 