### PR TITLE
Rename Equidate to Forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ and equity compensation.
   financials to establish the value of the stock, and this typically requires the
   cooperation of the company.
   There have been some efforts such as [SharesPost](http://sharespost.com/),
-  [Equidate](https://www.equidateinc.com/), and [EquityZen](https://equityzen.com/) to establish a
+  [Forge](https://forgeglobal.com), and [EquityZen](https://equityzen.com/) to establish a
   market around such sales, particularly for well-known pre-IPO companies, but it’s still
   not a routine practice.
   Quora has


### PR DESCRIPTION
Equidate has renamed itself to Forge.  Its website now redirects, so to avoid confusion I am updating this doc.  

See also [this press release](https://www.prnewswire.com/news-releases/equidate-inc-rebrands-as-forge-global-inc-increases-series-b-funding-round-to-85m-and-completes-1b-in-pre-ipo-trading-volume-300784176.html) and [Crunchbase](https://www.crunchbase.com/organization/equidate)